### PR TITLE
Suppress unneccessary error logs.

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -483,7 +483,7 @@ func (*UtilsStruct) GetBountyIdFromEvents(client *ethclient.Client, blockNumber 
 	for _, vLog := range logs {
 		data, unpackErr := abiUtils.Unpack(contractAbi, "Slashed", vLog.Data)
 		if unpackErr != nil {
-			log.Error(unpackErr)
+			log.Debug(unpackErr)
 			continue
 		}
 		topics := vLog.Topics

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -120,7 +120,7 @@ func (*UtilsStruct) IndexRevealEventsOfCurrentEpoch(client *ethclient.Client, bl
 	for _, vLog := range logs {
 		data, unpackErr := abiUtils.Unpack(contractAbi, "Revealed", vLog.Data)
 		if unpackErr != nil {
-			log.Error(unpackErr)
+			log.Debug(unpackErr)
 			continue
 		}
 		if epoch == data[0].(uint32) {


### PR DESCRIPTION
# Description

Error was getting logged while parsing the ABI for events. This might trigger unnecessary issues in monitoring. This PR converts those error logs to debug logs.

Fixes #925

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
