### PR TITLE
Hotfix-giveSorted fixes

### DIFF
--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -315,12 +315,12 @@ func (*UtilsStruct) Dispute(client *ethclient.Client, config types.Configuration
 	}
 
 	blockId := sortedProposedBlocks[blockIndex]
-	proposedBlock, err := razorUtils.GetProposedBlock(client, epoch, blockId)
+	updatedProposedBlock, err := razorUtils.GetProposedBlock(client, epoch, blockId)
 	if err != nil {
 		log.Error("Error in getting updated proposed block: ", err)
 		return err
 	}
-	if !proposedBlock.Valid {
+	if !updatedProposedBlock.Valid {
 		log.Debug("Block already disputed, not checking medians dispute again")
 		return errors.New("block already disputed")
 	}

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -164,6 +164,7 @@ type BlockManagerInterface interface {
 	DisputeCollectionIdShouldBePresent(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, blockIndex uint8, id uint16) (*Types.Transaction, error)
 	GiveSorted(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32, leafId uint16, sortedValues []*big.Int) (*Types.Transaction, error)
 	ResetDispute(blockManager *bindings.BlockManager, opts *bind.TransactOpts, epoch uint32) (*Types.Transaction, error)
+	Disputes(client *ethclient.Client, opts *bind.CallOpts, epoch uint32, address common.Address) (types.DisputesStruct, error)
 }
 
 type VoteManagerInterface interface {
@@ -287,10 +288,10 @@ type UtilsCmdInterface interface {
 	GetSortedRevealedValues(client *ethclient.Client, blockNumber *big.Int, epoch uint32) (*types.RevealedDataMaps, error)
 	GetIteration(client *ethclient.Client, proposer types.ElectedProposer, bufferPercent int32) int
 	Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error
-	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnArgs *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) error
+	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnArgs types.TransactionOptions, epoch uint32, assetId uint16, sortedStakers []*big.Int) error
 	GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) (types.ProposeFileData, error)
-	CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*Types.Transaction, error)
-	Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error
+	CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16, sortedProposedBlocks []uint32) (*Types.Transaction, error)
+	Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int, sortedProposedBlocks []uint32) error
 	GetCollectionIdPositionInBlock(client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int
 	HandleDispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error
 	ExecuteExtendLock(flagSet *pflag.FlagSet)
@@ -327,6 +328,7 @@ type UtilsCmdInterface interface {
 	ContractAddresses()
 	ResetDispute(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32)
 	StoreBountyId(client *ethclient.Client, account types.Account) error
+	CheckToDoResetDispute(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, sortedValues []*big.Int)
 }
 
 type TransactionInterface interface {

--- a/cmd/mocks/block_manager_interface.go
+++ b/cmd/mocks/block_manager_interface.go
@@ -8,6 +8,10 @@ import (
 
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind"
 
+	common "github.com/ethereum/go-ethereum/common"
+
+	coretypes "razor/core/types"
+
 	ethclient "github.com/ethereum/go-ethereum/ethclient"
 
 	mock "github.com/stretchr/testify/mock"
@@ -128,6 +132,27 @@ func (_m *BlockManagerInterface) DisputeOnOrderOfIds(client *ethclient.Client, o
 	var r1 error
 	if rf, ok := ret.Get(1).(func(*ethclient.Client, *bind.TransactOpts, uint32, uint8, *big.Int, *big.Int) error); ok {
 		r1 = rf(client, opts, epoch, blockIndex, index0, index1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Disputes provides a mock function with given fields: client, opts, epoch, address
+func (_m *BlockManagerInterface) Disputes(client *ethclient.Client, opts *bind.CallOpts, epoch uint32, address common.Address) (coretypes.DisputesStruct, error) {
+	ret := _m.Called(client, opts, epoch, address)
+
+	var r0 coretypes.DisputesStruct
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, *bind.CallOpts, uint32, common.Address) coretypes.DisputesStruct); ok {
+		r0 = rf(client, opts, epoch, address)
+	} else {
+		r0 = ret.Get(0).(coretypes.DisputesStruct)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, *bind.CallOpts, uint32, common.Address) error); ok {
+		r1 = rf(client, opts, epoch, address)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -153,13 +153,13 @@ func (_m *UtilsCmdInterface) CheckCurrentStatus(client *ethclient.Client, collec
 	return r0, r1
 }
 
-// CheckDisputeForIds provides a mock function with given fields: client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds
-func (_m *UtilsCmdInterface) CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*coretypes.Transaction, error) {
-	ret := _m.Called(client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds)
+// CheckDisputeForIds provides a mock function with given fields: client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds, sortedProposedBlocks
+func (_m *UtilsCmdInterface) CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16, sortedProposedBlocks []uint32) (*coretypes.Transaction, error) {
+	ret := _m.Called(client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds, sortedProposedBlocks)
 
 	var r0 *coretypes.Transaction
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.TransactionOptions, uint32, uint8, []uint16, []uint16) *coretypes.Transaction); ok {
-		r0 = rf(client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.TransactionOptions, uint32, uint8, []uint16, []uint16, []uint32) *coretypes.Transaction); ok {
+		r0 = rf(client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds, sortedProposedBlocks)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*coretypes.Transaction)
@@ -167,13 +167,18 @@ func (_m *UtilsCmdInterface) CheckDisputeForIds(client *ethclient.Client, transa
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, types.TransactionOptions, uint32, uint8, []uint16, []uint16) error); ok {
-		r1 = rf(client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds)
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, types.TransactionOptions, uint32, uint8, []uint16, []uint16, []uint32) error); ok {
+		r1 = rf(client, transactionOpts, epoch, blockIndex, idsInProposedBlock, revealedCollectionIds, sortedProposedBlocks)
 	} else {
 		r1 = ret.Error(1)
 	}
 
 	return r0, r1
+}
+
+// CheckToDoResetDispute provides a mock function with given fields: client, blockManager, txnOpts, epoch, sortedValues
+func (_m *UtilsCmdInterface) CheckToDoResetDispute(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, sortedValues []*big.Int) {
+	_m.Called(client, blockManager, txnOpts, epoch, sortedValues)
 }
 
 // ClaimBlockReward provides a mock function with given fields: options
@@ -345,13 +350,13 @@ func (_m *UtilsCmdInterface) Delegate(txnArgs types.TransactionOptions, stakerId
 	return r0, r1
 }
 
-// Dispute provides a mock function with given fields: client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues
-func (_m *UtilsCmdInterface) Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error {
-	ret := _m.Called(client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues)
+// Dispute provides a mock function with given fields: client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues, sortedProposedBlocks
+func (_m *UtilsCmdInterface) Dispute(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int, sortedProposedBlocks []uint32) error {
+	ret := _m.Called(client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues, sortedProposedBlocks)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, uint8, bindings.StructsBlock, uint16, []*big.Int) error); ok {
-		r0 = rf(client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, uint8, bindings.StructsBlock, uint16, []*big.Int, []uint32) error); ok {
+		r0 = rf(client, config, account, epoch, blockIndex, proposedBlock, leafId, sortedValues, sortedProposedBlocks)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -904,13 +909,13 @@ func (_m *UtilsCmdInterface) GetWaitTime() (int32, error) {
 	return r0, r1
 }
 
-// GiveSorted provides a mock function with given fields: client, blockManager, txnOpts, epoch, assetId, sortedStakers
-func (_m *UtilsCmdInterface) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) error {
-	ret := _m.Called(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
+// GiveSorted provides a mock function with given fields: client, blockManager, txnArgs, epoch, assetId, sortedStakers
+func (_m *UtilsCmdInterface) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnArgs types.TransactionOptions, epoch uint32, assetId uint16, sortedStakers []*big.Int) error {
+	ret := _m.Called(client, blockManager, txnArgs, epoch, assetId, sortedStakers)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, *bindings.BlockManager, *bind.TransactOpts, uint32, uint16, []*big.Int) error); ok {
-		r0 = rf(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, *bindings.BlockManager, types.TransactionOptions, uint32, uint16, []*big.Int) error); ok {
+		r0 = rf(client, blockManager, txnArgs, epoch, assetId, sortedStakers)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -658,6 +658,12 @@ func (blockManagerUtils BlockManagerUtils) ResetDispute(blockManager *bindings.B
 	return blockManager.ResetDispute(opts, epoch)
 }
 
+//This functiom gets Disputes mapping
+func (blockManagerUtils BlockManagerUtils) Disputes(client *ethclient.Client, opts *bind.CallOpts, epoch uint32, address common.Address) (types.DisputesStruct, error) {
+	blockManager := utilsInterface.GetBlockManager(client)
+	return blockManager.Disputes(opts, epoch, address)
+}
+
 //This function is used to reveal the values
 func (voteManagerUtils VoteManagerUtils) Reveal(client *ethclient.Client, opts *bind.TransactOpts, epoch uint32, tree bindings.StructsMerkleTree, signature []byte) (*Types.Transaction, error) {
 	voteManager := utilsInterface.GetVoteManager(client)
@@ -972,8 +978,8 @@ func (c CryptoUtils) HexToECDSA(hexKey string) (*ecdsa.PrivateKey, error) {
 }
 
 //This function is used to give the sorted Ids
-func (*UtilsStruct) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnOpts *bind.TransactOpts, epoch uint32, assetId uint16, sortedStakers []*big.Int) error {
-	return GiveSorted(client, blockManager, txnOpts, epoch, assetId, sortedStakers)
+func (*UtilsStruct) GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnArgs types.TransactionOptions, epoch uint32, assetId uint16, sortedStakers []*big.Int) error {
+	return GiveSorted(client, blockManager, txnArgs, epoch, assetId, sortedStakers)
 }
 
 //This function is used to write config as

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -228,21 +228,11 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 			break
 		}
 	case 3:
-		log.Debugf("Last verification: %d", lastVerification)
-		if lastVerification >= epoch {
-			log.Debugf("Last verification (%d) is greater or equal to current epoch (%d)", lastVerification, epoch)
-			log.Debugf("Won't dispute now")
-			break
-		}
-
 		err := cmdUtils.HandleDispute(client, config, account, epoch, blockNumber, rogueData)
 		if err != nil {
 			log.Error(err)
 			break
 		}
-
-		lastVerification = epoch
-
 		if utilsInterface.IsFlagPassed("autoClaimBounty") {
 			log.Debugf("Automatically claiming bounty")
 			err = cmdUtils.HandleClaimBounty(client, config, account)

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -9,3 +9,10 @@ type Block struct {
 	Block        bindings.StructsBlock
 	BlockMedians []*big.Int
 }
+
+type DisputesStruct struct {
+	LeafId           uint16
+	LastVisitedValue *big.Int
+	AccWeight        *big.Int
+	Median           *big.Int
+}

--- a/utils/client_methods.go
+++ b/utils/client_methods.go
@@ -11,14 +11,14 @@ import (
 	"razor/core"
 )
 
-func (*UtilsStruct) GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error) {
+func (*UtilsStruct) GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address) (uint64, error) {
 	var (
 		nonce uint64
 		err   error
 	)
 	err = retry.Do(
 		func() error {
-			nonce, err = ClientInterface.NonceAt(client, context.Background(), accountAddress, blockNumber)
+			nonce, err = ClientInterface.NonceAt(client, context.Background(), accountAddress)
 			if err != nil {
 				log.Error("Error in fetching nonce.... Retrying")
 				return err

--- a/utils/client_methods.go
+++ b/utils/client_methods.go
@@ -11,14 +11,14 @@ import (
 	"razor/core"
 )
 
-func (*UtilsStruct) GetPendingNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address) (uint64, error) {
+func (*UtilsStruct) GetPendingNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error) {
 	var (
 		nonce uint64
 		err   error
 	)
 	err = retry.Do(
 		func() error {
-			nonce, err = ClientInterface.PendingNonceAt(client, context.Background(), accountAddress)
+			nonce, err = ClientInterface.PendingNonceAt(client, context.Background(), accountAddress, blockNumber)
 			if err != nil {
 				log.Error("Error in fetching nonce.... Retrying")
 				return err

--- a/utils/client_methods.go
+++ b/utils/client_methods.go
@@ -11,14 +11,14 @@ import (
 	"razor/core"
 )
 
-func (*UtilsStruct) GetPendingNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error) {
+func (*UtilsStruct) GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error) {
 	var (
 		nonce uint64
 		err   error
 	)
 	err = retry.Do(
 		func() error {
-			nonce, err = ClientInterface.PendingNonceAt(client, context.Background(), accountAddress, blockNumber)
+			nonce, err = ClientInterface.NonceAt(client, context.Background(), accountAddress, blockNumber)
 			if err != nil {
 				log.Error("Error in fetching nonce.... Retrying")
 				return err

--- a/utils/client_methods_test.go
+++ b/utils/client_methods_test.go
@@ -300,7 +300,6 @@ func TestUtilsStruct_GetLatestBlockWithRetry(t *testing.T) {
 func TestUtilsStruct_GetNonceAtWithRetry(t *testing.T) {
 	var client *ethclient.Client
 	var accountAddress common.Address
-	var blockNumber *big.Int
 
 	type args struct {
 		nonce    uint64
@@ -342,7 +341,7 @@ func TestUtilsStruct_GetNonceAtWithRetry(t *testing.T) {
 			clientMock.On("NonceAt", mock.AnythingOfType("*ethclient.Client"), context.Background(), mock.AnythingOfType("common.Address"), mock.Anything).Return(tt.args.nonce, tt.args.nonceErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetNonceAtWithRetry(client, accountAddress, blockNumber)
+			got, err := utils.GetNonceAtWithRetry(client, accountAddress)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetNonceAtWithRetry() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/utils/client_methods_test.go
+++ b/utils/client_methods_test.go
@@ -297,9 +297,10 @@ func TestUtilsStruct_GetLatestBlockWithRetry(t *testing.T) {
 	}
 }
 
-func TestUtilsStruct_GetPendingNonceAtWithRetry(t *testing.T) {
+func TestUtilsStruct_GetNonceAtWithRetry(t *testing.T) {
 	var client *ethclient.Client
 	var accountAddress common.Address
+	var blockNumber *big.Int
 
 	type args struct {
 		nonce    uint64
@@ -338,16 +339,16 @@ func TestUtilsStruct_GetPendingNonceAtWithRetry(t *testing.T) {
 			}
 
 			utils := StartRazor(optionsPackageStruct)
-			clientMock.On("PendingNonceAt", mock.AnythingOfType("*ethclient.Client"), context.Background(), mock.AnythingOfType("common.Address")).Return(tt.args.nonce, tt.args.nonceErr)
+			clientMock.On("NonceAt", mock.AnythingOfType("*ethclient.Client"), context.Background(), mock.AnythingOfType("common.Address"), mock.Anything).Return(tt.args.nonce, tt.args.nonceErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetPendingNonceAtWithRetry(client, accountAddress)
+			got, err := utils.GetNonceAtWithRetry(client, accountAddress, blockNumber)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetPendingNonceAtWithRetry() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetNonceAtWithRetry() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("GetPendingNonceAtWithRetry() got = %v, want %v", got, tt.want)
+				t.Errorf("GetNonceAtWithRetry() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -71,7 +71,7 @@ var FlagSetInterface FlagSetUtils
 type Utils interface {
 	SuggestGasPriceWithRetry(client *ethclient.Client) (*big.Int, error)
 	MultiplyFloatAndBigInt(bigIntVal *big.Int, floatingVal float64) *big.Int
-	GetPendingNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error)
+	GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error)
 	GetGasPrice(client *ethclient.Client, config types.Configurations) *big.Int
 	GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts
 	GetGasLimit(transactionData types.TransactionOptions, txnOpts *bind.TransactOpts) (uint64, error)
@@ -182,7 +182,7 @@ type ClientUtils interface {
 	TransactionReceipt(client *ethclient.Client, ctx context.Context, txHash common.Hash) (*Types.Receipt, error)
 	BalanceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 	HeaderByNumber(client *ethclient.Client, ctx context.Context, number *big.Int) (*Types.Header, error)
-	PendingNonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
+	NonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
 	SuggestGasPrice(client *ethclient.Client, ctx context.Context) (*big.Int, error)
 	EstimateGas(client *ethclient.Client, ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	FilterLogs(client *ethclient.Client, ctx context.Context, q ethereum.FilterQuery) ([]Types.Log, error)

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -71,7 +71,7 @@ var FlagSetInterface FlagSetUtils
 type Utils interface {
 	SuggestGasPriceWithRetry(client *ethclient.Client) (*big.Int, error)
 	MultiplyFloatAndBigInt(bigIntVal *big.Int, floatingVal float64) *big.Int
-	GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error)
+	GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address) (uint64, error)
 	GetGasPrice(client *ethclient.Client, config types.Configurations) *big.Int
 	GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts
 	GetGasLimit(transactionData types.TransactionOptions, txnOpts *bind.TransactOpts) (uint64, error)
@@ -182,7 +182,7 @@ type ClientUtils interface {
 	TransactionReceipt(client *ethclient.Client, ctx context.Context, txHash common.Hash) (*Types.Receipt, error)
 	BalanceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 	HeaderByNumber(client *ethclient.Client, ctx context.Context, number *big.Int) (*Types.Header, error)
-	NonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
+	NonceAt(client *ethclient.Client, ctx context.Context, account common.Address) (uint64, error)
 	SuggestGasPrice(client *ethclient.Client, ctx context.Context) (*big.Int, error)
 	EstimateGas(client *ethclient.Client, ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	FilterLogs(client *ethclient.Client, ctx context.Context, q ethereum.FilterQuery) ([]Types.Log, error)

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -71,7 +71,7 @@ var FlagSetInterface FlagSetUtils
 type Utils interface {
 	SuggestGasPriceWithRetry(client *ethclient.Client) (*big.Int, error)
 	MultiplyFloatAndBigInt(bigIntVal *big.Int, floatingVal float64) *big.Int
-	GetPendingNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address) (uint64, error)
+	GetPendingNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error)
 	GetGasPrice(client *ethclient.Client, config types.Configurations) *big.Int
 	GetTxnOpts(transactionData types.TransactionOptions) *bind.TransactOpts
 	GetGasLimit(transactionData types.TransactionOptions, txnOpts *bind.TransactOpts) (uint64, error)
@@ -182,7 +182,7 @@ type ClientUtils interface {
 	TransactionReceipt(client *ethclient.Client, ctx context.Context, txHash common.Hash) (*Types.Receipt, error)
 	BalanceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 	HeaderByNumber(client *ethclient.Client, ctx context.Context, number *big.Int) (*Types.Header, error)
-	PendingNonceAt(client *ethclient.Client, ctx context.Context, account common.Address) (uint64, error)
+	PendingNonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
 	SuggestGasPrice(client *ethclient.Client, ctx context.Context) (*big.Int, error)
 	EstimateGas(client *ethclient.Client, ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	FilterLogs(client *ethclient.Client, ctx context.Context, q ethereum.FilterQuery) ([]Types.Log, error)

--- a/utils/mocks/client_utils.go
+++ b/utils/mocks/client_utils.go
@@ -112,20 +112,20 @@ func (_m *ClientUtils) HeaderByNumber(client *ethclient.Client, ctx context.Cont
 	return r0, r1
 }
 
-// PendingNonceAt provides a mock function with given fields: client, ctx, account
-func (_m *ClientUtils) PendingNonceAt(client *ethclient.Client, ctx context.Context, account common.Address) (uint64, error) {
-	ret := _m.Called(client, ctx, account)
+// NonceAt provides a mock function with given fields: client, ctx, account, blockNumber
+func (_m *ClientUtils) NonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
+	ret := _m.Called(client, ctx, account, blockNumber)
 
 	var r0 uint64
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, context.Context, common.Address) uint64); ok {
-		r0 = rf(client, ctx, account)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, context.Context, common.Address, *big.Int) uint64); ok {
+		r0 = rf(client, ctx, account, blockNumber)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, context.Context, common.Address) error); ok {
-		r1 = rf(client, ctx, account)
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, context.Context, common.Address, *big.Int) error); ok {
+		r1 = rf(client, ctx, account, blockNumber)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/utils/mocks/client_utils.go
+++ b/utils/mocks/client_utils.go
@@ -112,20 +112,20 @@ func (_m *ClientUtils) HeaderByNumber(client *ethclient.Client, ctx context.Cont
 	return r0, r1
 }
 
-// NonceAt provides a mock function with given fields: client, ctx, account, blockNumber
-func (_m *ClientUtils) NonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error) {
-	ret := _m.Called(client, ctx, account, blockNumber)
+// NonceAt provides a mock function with given fields: client, ctx, account
+func (_m *ClientUtils) NonceAt(client *ethclient.Client, ctx context.Context, account common.Address) (uint64, error) {
+	ret := _m.Called(client, ctx, account)
 
 	var r0 uint64
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, context.Context, common.Address, *big.Int) uint64); ok {
-		r0 = rf(client, ctx, account, blockNumber)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, context.Context, common.Address) uint64); ok {
+		r0 = rf(client, ctx, account)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, context.Context, common.Address, *big.Int) error); ok {
-		r1 = rf(client, ctx, account, blockNumber)
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, context.Context, common.Address) error); ok {
+		r1 = rf(client, ctx, account)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -1162,20 +1162,20 @@ func (_m *Utils) GetMinStakeAmount(client *ethclient.Client) (*big.Int, error) {
 	return r0, r1
 }
 
-// GetNonceAtWithRetry provides a mock function with given fields: client, accountAddress, blockNumber
-func (_m *Utils) GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error) {
-	ret := _m.Called(client, accountAddress, blockNumber)
+// GetNonceAtWithRetry provides a mock function with given fields: client, accountAddress
+func (_m *Utils) GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address) (uint64, error) {
+	ret := _m.Called(client, accountAddress)
 
 	var r0 uint64
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, common.Address, *big.Int) uint64); ok {
-		r0 = rf(client, accountAddress, blockNumber)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, common.Address) uint64); ok {
+		r0 = rf(client, accountAddress)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, common.Address, *big.Int) error); ok {
-		r1 = rf(client, accountAddress, blockNumber)
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, common.Address) error); ok {
+		r1 = rf(client, accountAddress)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -1162,6 +1162,27 @@ func (_m *Utils) GetMinStakeAmount(client *ethclient.Client) (*big.Int, error) {
 	return r0, r1
 }
 
+// GetNonceAtWithRetry provides a mock function with given fields: client, accountAddress, blockNumber
+func (_m *Utils) GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address, blockNumber *big.Int) (uint64, error) {
+	ret := _m.Called(client, accountAddress, blockNumber)
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, common.Address, *big.Int) uint64); ok {
+		r0 = rf(client, accountAddress, blockNumber)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, common.Address, *big.Int) error); ok {
+		r1 = rf(client, accountAddress, blockNumber)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetNumActiveCollections provides a mock function with given fields: client
 func (_m *Utils) GetNumActiveCollections(client *ethclient.Client) (uint16, error) {
 	ret := _m.Called(client)
@@ -1258,27 +1279,6 @@ func (_m *Utils) GetOptions() bind.CallOpts {
 	}
 
 	return r0
-}
-
-// GetPendingNonceAtWithRetry provides a mock function with given fields: client, accountAddress
-func (_m *Utils) GetPendingNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address) (uint64, error) {
-	ret := _m.Called(client, accountAddress)
-
-	var r0 uint64
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, common.Address) uint64); ok {
-		r0 = rf(client, accountAddress)
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, common.Address) error); ok {
-		r1 = rf(client, accountAddress)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // GetProposedBlock provides a mock function with given fields: client, epoch, proposedBlockId

--- a/utils/options.go
+++ b/utils/options.go
@@ -34,7 +34,8 @@ func (*UtilsStruct) GetTxnOpts(transactionData types.TransactionOptions) *bind.T
 	if privateKey == nil || err != nil {
 		CheckError("Error in fetching private key: ", errors.New(transactionData.AccountAddress+" not present in razor-go"))
 	}
-	nonce, err := UtilsInterface.GetPendingNonceAtWithRetry(transactionData.Client, common.HexToAddress(transactionData.AccountAddress))
+	callOpts := UtilsInterface.GetOptions()
+	nonce, err := UtilsInterface.GetPendingNonceAtWithRetry(transactionData.Client, common.HexToAddress(transactionData.AccountAddress), callOpts.BlockNumber)
 	CheckError("Error in fetching pending nonce: ", err)
 
 	gasPrice := UtilsInterface.GetGasPrice(transactionData.Client, transactionData.Config)

--- a/utils/options.go
+++ b/utils/options.go
@@ -35,7 +35,7 @@ func (*UtilsStruct) GetTxnOpts(transactionData types.TransactionOptions) *bind.T
 		CheckError("Error in fetching private key: ", errors.New(transactionData.AccountAddress+" not present in razor-go"))
 	}
 	callOpts := UtilsInterface.GetOptions()
-	nonce, err := UtilsInterface.GetPendingNonceAtWithRetry(transactionData.Client, common.HexToAddress(transactionData.AccountAddress), callOpts.BlockNumber)
+	nonce, err := UtilsInterface.GetNonceAtWithRetry(transactionData.Client, common.HexToAddress(transactionData.AccountAddress), callOpts.BlockNumber)
 	CheckError("Error in fetching pending nonce: ", err)
 
 	gasPrice := UtilsInterface.GetGasPrice(transactionData.Client, transactionData.Config)

--- a/utils/options.go
+++ b/utils/options.go
@@ -34,8 +34,7 @@ func (*UtilsStruct) GetTxnOpts(transactionData types.TransactionOptions) *bind.T
 	if privateKey == nil || err != nil {
 		CheckError("Error in fetching private key: ", errors.New(transactionData.AccountAddress+" not present in razor-go"))
 	}
-	callOpts := UtilsInterface.GetOptions()
-	nonce, err := UtilsInterface.GetNonceAtWithRetry(transactionData.Client, common.HexToAddress(transactionData.AccountAddress), callOpts.BlockNumber)
+	nonce, err := UtilsInterface.GetNonceAtWithRetry(transactionData.Client, common.HexToAddress(transactionData.AccountAddress))
 	CheckError("Error in fetching pending nonce: ", err)
 
 	gasPrice := UtilsInterface.GetGasPrice(transactionData.Client, transactionData.Config)

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -133,7 +133,6 @@ func Test_getGasPrice(t *testing.T) {
 func Test_utils_GetTxnOpts(t *testing.T) {
 	var transactionData types.TransactionOptions
 	var gasPrice *big.Int
-	var callOpts bind.CallOpts
 
 	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
@@ -287,8 +286,7 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 
 			pathMock.On("GetDefaultPath").Return(tt.args.path, tt.args.pathErr)
 			accountsMock.On("GetPrivateKey", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(tt.args.privateKey, nil)
-			utilsMock.On("GetOptions").Return(callOpts)
-			utilsMock.On("GetNonceAtWithRetry", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("common.Address"), mock.Anything).Return(tt.args.nonce, tt.args.nonceErr)
+			utilsMock.On("GetNonceAtWithRetry", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("common.Address")).Return(tt.args.nonce, tt.args.nonceErr)
 			utilsMock.On("GetGasPrice", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("types.Configurations")).Return(gasPrice)
 			bindMock.On("NewKeyedTransactorWithChainID", mock.AnythingOfType("*ecdsa.PrivateKey"), mock.AnythingOfType("*big.Int")).Return(tt.args.txnOpts, tt.args.txnOptsErr)
 			utilsMock.On("GetGasLimit", transactionData, txnOpts).Return(tt.args.gasLimit, tt.args.gasLimitErr)

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -133,6 +133,7 @@ func Test_getGasPrice(t *testing.T) {
 func Test_utils_GetTxnOpts(t *testing.T) {
 	var transactionData types.TransactionOptions
 	var gasPrice *big.Int
+	var callOpts bind.CallOpts
 
 	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
@@ -286,7 +287,8 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 
 			pathMock.On("GetDefaultPath").Return(tt.args.path, tt.args.pathErr)
 			accountsMock.On("GetPrivateKey", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(tt.args.privateKey, nil)
-			utilsMock.On("GetPendingNonceAtWithRetry", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("common.Address")).Return(tt.args.nonce, tt.args.nonceErr)
+			utilsMock.On("GetOptions").Return(callOpts)
+			utilsMock.On("GetNonceAtWithRetry", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("common.Address"), mock.Anything).Return(tt.args.nonce, tt.args.nonceErr)
 			utilsMock.On("GetGasPrice", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("types.Configurations")).Return(gasPrice)
 			bindMock.On("NewKeyedTransactorWithChainID", mock.AnythingOfType("*ecdsa.PrivateKey"), mock.AnythingOfType("*big.Int")).Return(tt.args.txnOpts, tt.args.txnOptsErr)
 			utilsMock.On("GetGasLimit", transactionData, txnOpts).Return(tt.args.gasLimit, tt.args.gasLimitErr)

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -311,8 +311,8 @@ func (c ClientStruct) HeaderByNumber(client *ethclient.Client, ctx context.Conte
 	return client.HeaderByNumber(ctx, number)
 }
 
-func (c ClientStruct) NonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blocknumber *big.Int) (uint64, error) {
-	return client.NonceAt(ctx, account, blocknumber)
+func (c ClientStruct) NonceAt(client *ethclient.Client, ctx context.Context, account common.Address) (uint64, error) {
+	return client.NonceAt(ctx, account, nil)
 }
 
 func (c ClientStruct) SuggestGasPrice(client *ethclient.Client, ctx context.Context) (*big.Int, error) {

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -311,8 +311,8 @@ func (c ClientStruct) HeaderByNumber(client *ethclient.Client, ctx context.Conte
 	return client.HeaderByNumber(ctx, number)
 }
 
-func (c ClientStruct) PendingNonceAt(client *ethclient.Client, ctx context.Context, account common.Address) (uint64, error) {
-	return client.PendingNonceAt(ctx, account)
+func (c ClientStruct) PendingNonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blocknumber *big.Int) (uint64, error) {
+	return client.NonceAt(ctx, account, blocknumber)
 }
 
 func (c ClientStruct) SuggestGasPrice(client *ethclient.Client, ctx context.Context) (*big.Int, error) {

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -311,7 +311,7 @@ func (c ClientStruct) HeaderByNumber(client *ethclient.Client, ctx context.Conte
 	return client.HeaderByNumber(ctx, number)
 }
 
-func (c ClientStruct) PendingNonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blocknumber *big.Int) (uint64, error) {
+func (c ClientStruct) NonceAt(client *ethclient.Client, ctx context.Context, account common.Address, blocknumber *big.Int) (uint64, error) {
 	return client.NonceAt(ctx, account, blocknumber)
 }
 


### PR DESCRIPTION
# Description

- Nonce calculated from conformed transaction, changed `PendingNonceAt` to `NonceAt`
- Checked Disputes state from blockchain before every dispute action
- Added checks whether block is already disputed or not
- Dispute calculation is on throughout dispute state.

Fixes #911


