### PR TITLE
hotfix-API attempts and timeout

### DIFF
--- a/utils/api.go
+++ b/utils/api.go
@@ -12,7 +12,7 @@ import (
 
 func (*UtilsStruct) GetDataFromAPI(url string) ([]byte, error) {
 	client := http.Client{
-		Timeout: 60 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 	var body []byte
 	err := retry.Do(

--- a/utils/asset.go
+++ b/utils/asset.go
@@ -12,6 +12,7 @@ import (
 	"razor/pkg/bindings"
 	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/avast/retry-go"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -273,11 +274,14 @@ func (*UtilsStruct) GetDataToCommitFromJob(job bindings.StructsJob) (*big.Int, e
 	// Fetch data from API with retry mechanism
 	var parsedData interface{}
 	if job.SelectorType == 0 {
+		start := time.Now()
 		response, apiErr = UtilsInterface.GetDataFromAPI(job.Url)
 		if apiErr != nil {
 			log.Error("Error in fetching data from API: ", apiErr)
 			return nil, apiErr
 		}
+		elapsed := time.Since(start).Seconds()
+		log.Debugf("Time taken to fetch the data from API : %s was %f", job.Url, elapsed)
 
 		err := json.Unmarshal(response, &parsedJSON)
 		if err != nil {


### PR DESCRIPTION
# Description

- Changed HTTP timeout to 10 sec.
- Total Number of Attempts (first attempt + no. of retries) = 2
- Logged time elapsed to fetch data for each API .

Fixes #950

## Type of change
