### PR TITLE
Validate contract calls (Changes from v1-audit)

### DIFF
--- a/cmd/addStake.go
+++ b/cmd/addStake.go
@@ -64,6 +64,15 @@ func (*UtilsStruct) ExecuteStake(flagSet *pflag.FlagSet) {
 		log.Fatal("The amount of razors entered is below min safe value.")
 	}
 
+	if stakerId != 0 {
+		staker, err := razorUtils.GetStaker(client, stakerId)
+		utils.CheckError("Error in getting staker: ", err)
+
+		if staker.IsSlashed {
+			log.Fatal("Staker is slashed, cannot stake")
+		}
+	}
+
 	txnArgs := types.TransactionOptions{
 		Client:         client,
 		AccountAddress: address,

--- a/cmd/initiateWithdraw.go
+++ b/cmd/initiateWithdraw.go
@@ -102,11 +102,7 @@ func (*UtilsStruct) HandleUnstakeLock(client *ethclient.Client, account types.Ac
 	waitFor := big.NewInt(0).Sub(unstakeLock.UnlockAfter, big.NewInt(int64(epoch)))
 	if waitFor.Cmp(big.NewInt(0)) > 0 {
 		timeRemaining := int64(uint32(waitFor.Int64())) * core.EpochLength
-		if waitFor.Cmp(big.NewInt(1)) == 0 {
-			log.Infof("Withdrawal period not reached. Cannot withdraw now, please wait for %d epoch! (approximately %s)", waitFor, razorUtils.SecondsToReadableTime(int(timeRemaining)))
-		} else {
-			log.Infof("Withdrawal period not reached. Cannot withdraw now, please wait for %d epochs! (approximately %s)", waitFor, razorUtils.SecondsToReadableTime(int(timeRemaining)))
-		}
+		log.Infof("Withdrawal Initiation period not reached. Cannot initiate withdraw now, please wait for %d epoch(s)! (approximately %s)", waitFor, razorUtils.SecondsToReadableTime(int(timeRemaining)))
 		return core.NilHash, nil
 	}
 

--- a/cmd/struct-utils.go
+++ b/cmd/struct-utils.go
@@ -915,17 +915,29 @@ func (flagSetUtils FLagSetUtils) GetRootInt64RPCTimeout() (int64, error) {
 
 //This function returns the from in string
 func (flagSetUtils FLagSetUtils) GetStringFrom(flagSet *pflag.FlagSet) (string, error) {
-	return flagSet.GetString("from")
+	from, err := flagSet.GetString("from")
+	if err != nil {
+		return "", err
+	}
+	return utils.ValidateAddress(from)
 }
 
 //This function returns the to in string
 func (flagSetUtils FLagSetUtils) GetStringTo(flagSet *pflag.FlagSet) (string, error) {
-	return flagSet.GetString("to")
+	to, err := flagSet.GetString("to")
+	if err != nil {
+		return "", err
+	}
+	return utils.ValidateAddress(to)
 }
 
 //This function returns the address in string
 func (flagSetUtils FLagSetUtils) GetStringAddress(flagSet *pflag.FlagSet) (string, error) {
-	return flagSet.GetString("address")
+	address, err := flagSet.GetString("address")
+	if err != nil {
+		return "", err
+	}
+	return utils.ValidateAddress(address)
 }
 
 //This function returns the stakerId in Uint32

--- a/cmd/unlockWithdraw.go
+++ b/cmd/unlockWithdraw.go
@@ -79,6 +79,13 @@ func (*UtilsStruct) HandleWithdrawLock(client *ethclient.Client, account types.A
 		return core.NilHash, err
 	}
 
+	waitFor := big.NewInt(0).Sub(withdrawLock.UnlockAfter, big.NewInt(int64(epoch)))
+	if waitFor.Cmp(big.NewInt(0)) > 0 {
+		timeRemaining := int64(uint32(waitFor.Int64())) * core.EpochLength
+		log.Infof("Withdrawal period not reached. Cannot withdraw now, please wait for %d epoch(s)! (approximately %s)", waitFor, razorUtils.SecondsToReadableTime(int(timeRemaining)))
+		return core.NilHash, nil
+	}
+
 	if big.NewInt(int64(epoch)).Cmp(withdrawLock.UnlockAfter) >= 0 {
 		txnArgs := types.TransactionOptions{
 			Client:          client,

--- a/cmd/unlockWithdraw_test.go
+++ b/cmd/unlockWithdraw_test.go
@@ -143,6 +143,7 @@ func TestHandleWithdrawLock(t *testing.T) {
 		txnOpts           *bind.TransactOpts
 		unlockWithdraw    common.Hash
 		unlockWithdrawErr error
+		time              string
 	}
 	tests := []struct {
 		name    string
@@ -200,9 +201,10 @@ func TestHandleWithdrawLock(t *testing.T) {
 					UnlockAfter: big.NewInt(4),
 				},
 				epoch: 3,
+				time:  "20 minutes 0 seconds",
 			},
 			want:    core.NilHash,
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -218,7 +220,7 @@ func TestHandleWithdrawLock(t *testing.T) {
 			utilsMock.On("GetEpoch", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.epoch, tt.args.epochErr)
 			utilsMock.On("GetTxnOpts", mock.AnythingOfType("types.TransactionOptions")).Return(txnOpts)
 			cmdUtilsMock.On("UnlockWithdraw", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.unlockWithdraw, tt.args.unlockWithdrawErr)
-
+			utilsMock.On("SecondsToReadableTime", mock.AnythingOfType("int")).Return(tt.args.time)
 			ut := &UtilsStruct{}
 			got, err := ut.HandleWithdrawLock(client, account, configurations, stakerId)
 			if (err != nil) != tt.wantErr {

--- a/utils/common.go
+++ b/utils/common.go
@@ -109,17 +109,17 @@ func CheckError(msg string, err error) {
 	}
 }
 
-func IsValidERC20Address(address string) bool {
+func IsValidAddress(address string) bool {
 	if !common.IsHexAddress(address) {
-		log.Error("Invalid ERC20 Address")
+		log.Error("Invalid Address")
 		return false
 	}
 	return true
 }
 
 func ValidateAddress(address string) (string, error) {
-	if !IsValidERC20Address(address) {
-		return "", errors.New("invalid erc20 address")
+	if !IsValidAddress(address) {
+		return "", errors.New("invalid address")
 	}
 	return address, nil
 }

--- a/utils/common.go
+++ b/utils/common.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"github.com/avast/retry-go"
 	"math/big"
 	"os"
 	"razor/core"
@@ -26,10 +27,26 @@ func (*UtilsStruct) ConnectToClient(provider string) *ethclient.Client {
 }
 
 func (*UtilsStruct) FetchBalance(client *ethclient.Client, accountAddress string) (*big.Int, error) {
-	address := common.HexToAddress(accountAddress)
-	coinContract := UtilsInterface.GetTokenManager(client)
-	opts := UtilsInterface.GetOptions()
-	return CoinInterface.BalanceOf(coinContract, &opts, address)
+	var (
+		balance *big.Int
+		err     error
+	)
+	err = retry.Do(
+		func() error {
+			address := common.HexToAddress(accountAddress)
+			erc20Contract := UtilsInterface.GetTokenManager(client)
+			opts := UtilsInterface.GetOptions()
+			balance, err = CoinInterface.BalanceOf(erc20Contract, &opts, address)
+			if err != nil {
+				log.Error("Error in fetching balance....Retrying")
+				return err
+			}
+			return nil
+		}, RetryInterface.RetryAttempts(core.MaxRetries))
+	if err != nil {
+		return big.NewInt(0), err
+	}
+	return balance, nil
 }
 
 func (*UtilsStruct) GetDelayedState(client *ethclient.Client, buffer int32) (int64, error) {

--- a/utils/common.go
+++ b/utils/common.go
@@ -109,6 +109,21 @@ func CheckError(msg string, err error) {
 	}
 }
 
+func IsValidERC20Address(address string) bool {
+	if !common.IsHexAddress(address) {
+		log.Error("Invalid ERC20 Address")
+		return false
+	}
+	return true
+}
+
+func ValidateAddress(address string) (string, error) {
+	if !IsValidERC20Address(address) {
+		return "", errors.New("invalid erc20 address")
+	}
+	return address, nil
+}
+
 func (*UtilsStruct) IsFlagPassed(name string) bool {
 	found := false
 	for _, arg := range os.Args {

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -717,7 +717,7 @@ func TestWaitTillNextNSecs(t *testing.T) {
 	}
 }
 
-func TestIsValidERC20Address(t *testing.T) {
+func TestIsValidAddress(t *testing.T) {
 	type args struct {
 		address string
 	}
@@ -727,14 +727,14 @@ func TestIsValidERC20Address(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "Test 1: When correct erc20 address is passed",
+			name: "Test 1: When correct address is passed",
 			args: args{
 				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90e",
 			},
 			want: true,
 		},
 		{
-			name: "Test 2: When incorrect erc20 address is passed",
+			name: "Test 2: When incorrect address is passed",
 			args: args{
 				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90z",
 			},
@@ -750,8 +750,8 @@ func TestIsValidERC20Address(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsValidERC20Address(tt.args.address); got != tt.want {
-				t.Errorf("IsValidERC20Address() = %v, want %v", got, tt.want)
+			if got := IsValidAddress(tt.args.address); got != tt.want {
+				t.Errorf("IsValidAddress() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -768,7 +768,7 @@ func TestIsValidateAddress(t *testing.T) {
 		wantErr     error
 	}{
 		{
-			name: "Test 1: When correct erc20 address is passed",
+			name: "Test 1: When correct address is passed",
 			args: args{
 				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90e",
 			},
@@ -776,12 +776,12 @@ func TestIsValidateAddress(t *testing.T) {
 			wantErr:     nil,
 		},
 		{
-			name: "Test 2: When incorrect erc20 address is passed",
+			name: "Test 2: When incorrect address is passed",
 			args: args{
 				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90z",
 			},
 			wantAddress: "",
-			wantErr:     errors.New("invalid erc20 address"),
+			wantErr:     errors.New("invalid address"),
 		},
 		{
 			name: "Test 2: When nil is passed",
@@ -789,7 +789,7 @@ func TestIsValidateAddress(t *testing.T) {
 				address: "",
 			},
 			wantAddress: "",
-			wantErr:     errors.New("invalid erc20 address"),
+			wantErr:     errors.New("invalid address"),
 		},
 	}
 	for _, tt := range tests {

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"github.com/avast/retry-go"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -301,61 +302,60 @@ func TestFetchBalance(t *testing.T) {
 	var callOpts bind.CallOpts
 
 	type args struct {
-		coinContract *bindings.RAZOR
-		balance      *big.Int
-		balanceErr   error
+		erc20Contract *bindings.RAZOR
+		balance       *big.Int
+		balanceErr    error
 	}
 	tests := []struct {
-		name          string
-		args          args
-		expectedFatal bool
-		wantErr       error
+		name    string
+		args    args
+		want    *big.Int
+		wantErr bool
 	}{
 		{
 			name: "When FetchBalance() executes successfully",
 			args: args{
-				coinContract: &bindings.RAZOR{},
-				balance:      big.NewInt(1),
+				erc20Contract: &bindings.RAZOR{},
+				balance:       big.NewInt(1),
 			},
-			expectedFatal: false,
-			wantErr:       nil,
+			want:    big.NewInt(1),
+			wantErr: false,
+		},
+		{
+			name: "When there is an error in fetching balance",
+			args: args{
+				erc20Contract: &bindings.RAZOR{},
+				balanceErr:    errors.New("error in fetching balance"),
+			},
+			want:    big.NewInt(0),
+			wantErr: true,
 		},
 	}
-
-	defer func() { log.ExitFunc = nil }()
-	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			utilsMock := new(mocks.Utils)
-			coinMock := new(mocks.CoinUtils)
+			erc20Mock := new(mocks.CoinUtils)
+			retryMock := new(mocks.RetryUtils)
 
 			optionsPackageStruct := OptionsPackageStruct{
 				UtilsInterface: utilsMock,
-				CoinInterface:  coinMock,
+				CoinInterface:  erc20Mock,
+				RetryInterface: retryMock,
 			}
 			utils := StartRazor(optionsPackageStruct)
 
-			utilsMock.On("GetTokenManager", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.coinContract)
+			utilsMock.On("GetTokenManager", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.erc20Contract)
 			utilsMock.On("GetOptions").Return(callOpts)
-			coinMock.On("BalanceOf", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.balance, tt.args.balanceErr)
+			erc20Mock.On("BalanceOf", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.balance, tt.args.balanceErr)
+			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			fatal = false
-
-			_, err := utils.FetchBalance(client, accountAddress)
-			if fatal != tt.expectedFatal {
-				t.Error("The FetchBalance function didn't execute as expected")
+			got, err := utils.FetchBalance(client, accountAddress)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FetchBalance() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
-			if err == nil || tt.wantErr == nil {
-				if err != tt.wantErr {
-					t.Errorf("Error for FetchBalance function, got = %v, want = %v", err, tt.wantErr)
-				}
-			} else {
-				if err.Error() != tt.wantErr.Error() {
-					t.Errorf("Error for fetchBalance function, got = %v, want = %v", err, tt.wantErr)
-				}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FetchBalance() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -717,6 +717,100 @@ func TestWaitTillNextNSecs(t *testing.T) {
 	}
 }
 
+func TestIsValidERC20Address(t *testing.T) {
+	type args struct {
+		address string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test 1: When correct erc20 address is passed",
+			args: args{
+				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90e",
+			},
+			want: true,
+		},
+		{
+			name: "Test 2: When incorrect erc20 address is passed",
+			args: args{
+				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90z",
+			},
+			want: false,
+		},
+		{
+			name: "Test 2: When nil is passed",
+			args: args{
+				address: "",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidERC20Address(tt.args.address); got != tt.want {
+				t.Errorf("IsValidERC20Address() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidateAddress(t *testing.T) {
+	type args struct {
+		address string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantAddress string
+		wantErr     error
+	}{
+		{
+			name: "Test 1: When correct erc20 address is passed",
+			args: args{
+				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90e",
+			},
+			wantAddress: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90e",
+			wantErr:     nil,
+		},
+		{
+			name: "Test 2: When incorrect erc20 address is passed",
+			args: args{
+				address: "0x8797EA6306881D74c4311C08C0Ca2C0a76dDC90z",
+			},
+			wantAddress: "",
+			wantErr:     errors.New("invalid erc20 address"),
+		},
+		{
+			name: "Test 2: When nil is passed",
+			args: args{
+				address: "",
+			},
+			wantAddress: "",
+			wantErr:     errors.New("invalid erc20 address"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := ValidateAddress(tt.args.address)
+			if got != tt.wantAddress {
+				t.Errorf("ValidateAddress() returns address = %v, want address = %v", got, tt.wantAddress)
+			}
+			if gotErr == nil || tt.wantErr == nil {
+				if gotErr != tt.wantErr {
+					t.Errorf("Error for ValidateAddress(), got error = %v, want error = %v", gotErr, tt.wantErr)
+				}
+			} else {
+				if gotErr.Error() != tt.wantErr.Error() {
+					t.Errorf("Error for ValidateAddress(), got error = %v, want error = %v", gotErr, tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
 func TestAssignStakerId(t *testing.T) {
 	var flagSet *pflag.FlagSet
 	var client *ethclient.Client


### PR DESCRIPTION
# Description

The PR contains the some of the changes which were merged to v1-audit branch but not used for prod.
 
- Added retry mechanism for fetchBalance
- Added ETA for unlockWithdraw
- Added check for staker is slashed for stake
- Added valid ERC20 address check for address which are input from flags  

Fixes #979
