### PR TITLE
Added support for Post Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,13 +555,13 @@ docker exec -it razor-go razor createJob --url <URL> --selector <selector_in_jso
 Example:
 
 ```
-$ ./razor createJob --url https://www.alphavantage.co/query\?function\=GLOBAL_QUOTE\&symbol\=MSFT\&apikey\=demo --selector '[`Global Quote`][`05. price`]" --selectorType 1 --name msft --power 2 --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --weight 32
+$  ./razor createJob --selectorType 0 --address 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --weight 1 --power 2 --name ethusd_kraken --selector 'result.XETHZUSD.c[0]' --url '{"type":"GET","url":"https://api.kraken.com/0/public/Ticker?pair=ETHUSD","body":{},"content-type":""}'
 ```
 
 OR
 
 ```
-$  ./razor createJob --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c -n btc_gecko --power 2 -s 'table tbody tr td span[data-coin-id="1"][data-target="price.price"] span' -u https://www.coingecko.com/en --selectorType 0 --weight 100
+$  ./razor createJob --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c -n btc_gecko --power 2 -s 'table tbody tr td span[data-coin-id="1"][data-target="price.price"] span' -u {"type":"GET","url":"https://www.coingecko.com/en","body":{},"content-type":""} --selectorType 0 --weight 100
 ```
 
 ### Create Collection
@@ -844,30 +844,35 @@ Shown below is an example of how your `assets.json` file should be -
 
 ```
 {
-  "assets": {
-    "collection": {
-      "ethCollectionMean": {
-        "power": 2,
-        "official jobs": {
-          "1": {
-            "URL": "https://data.messari.io/api/v1/assets/eth/metrics",
-            "selector": "[`data`][`market_data`][`price_usd`]",
-            "power": 2,
-            "weight": 2
-          },
-        },
-        "custom jobs": [
-          {
-            "URL": "https://api.lunarcrush.com/v2?data=assets&symbol=ETH",
-            "selector": "[`data`][`0`][`price`]",
-            "power": 3,
-            "weight": 2
-          },
-        ]
-      }
-    }
-  }
-}
+	"assets": {
+		"collection": {
+			"ethCollectionMedian": {
+				"power": 2,
+				"official jobs": {
+					"1": {
+					  "URL": {
+						   "type": "GET",
+						   "url": "https://data.messari.io/api/v1/assets/eth/metrics",
+						   "body": {},
+						   "content-type": ""
+						},
+						"selector": "[`data`][`market_data`][`price_usd`]",
+						"power": 2,
+						"weight": 2
+					},
+				},
+				"custom jobs": [{
+						"URL": {
+							"type": "GET",
+							"url": "https: //api.lunarcrush.com/v2?data=assets&symbol=ETH",
+							"body": {},
+							"content-type": ""
+						},
+					]
+				}
+			}
+		}
+	}
 ```
 
 Breaking down into components

--- a/core/types/assets.go
+++ b/core/types/assets.go
@@ -55,3 +55,10 @@ type CustomJob struct {
 	Power    int8   `json:"power"`
 	Weight   uint8  `json:"weight"`
 }
+
+type DataSourceURL struct {
+	Type        string                 `json:"type"`
+	URL         string                 `json:"url"`
+	Body        map[string]interface{} `json:"body"`
+	ContentType string                 `json:"content-type"`
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -62,9 +62,6 @@ func InitializeLogger(fileName string, config types.Configurations) {
 			MaxBackups: config.LogFileMaxBackups,
 			MaxAge:     config.LogFileMaxAge,
 		}
-		fmt.Println(config.LogFileMaxSize)
-		fmt.Println(config.LogFileMaxBackups)
-		fmt.Println(config.LogFileMaxAge)
 
 		out := os.Stderr
 		mw := io.MultiWriter(out, lumberJackLogger)

--- a/utils/api.go
+++ b/utils/api.go
@@ -13,13 +13,10 @@ import (
 	"time"
 )
 
-//'https://staging-v2.skalenodes.com/v1/whispering-turais  -X POST -H "Content-Type: application/json"}'
-//[]byte(`{"Type":1,"name":"test"}`
 func (*UtilsStruct) GetDataFromAPI(dataSourceURLStruct types.DataSourceURL) ([]byte, error) {
 	client := http.Client{
 		Timeout: 10 * time.Second,
 	}
-
 	var body []byte
 	if dataSourceURLStruct.Type == "GET" {
 		err := retry.Do(

--- a/utils/api.go
+++ b/utils/api.go
@@ -15,21 +15,12 @@ import (
 
 //'https://staging-v2.skalenodes.com/v1/whispering-turais  -X POST -H "Content-Type: application/json"}'
 //[]byte(`{"Type":1,"name":"test"}`
-func (*UtilsStruct) GetDataFromAPI(dataSourceURL string) ([]byte, error) {
+func (*UtilsStruct) GetDataFromAPI(dataSourceURLStruct types.DataSourceURL) ([]byte, error) {
 	client := http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	dataSourceURLInBytes := []byte(dataSourceURL)
-	var dataSourceURLStruct types.DataSourceURL
 	var body []byte
-
-	err := json.Unmarshal(dataSourceURLInBytes, &dataSourceURLStruct)
-	if err != nil {
-		log.Errorf("Error in unmarshalling %s: %v", dataSourceURL, err)
-		return body, err
-	}
-	log.Infof("URL Struct: %+v", dataSourceURLStruct)
 	if dataSourceURLStruct.Type == "GET" {
 		err := retry.Do(
 			func() error {
@@ -92,13 +83,13 @@ func (*UtilsStruct) GetDataFromJSON(jsonObject map[string]interface{}, selector 
 	return jsonpath.Get(selector, jsonObject)
 }
 
-func (*UtilsStruct) GetDataFromXHTML(url string, selector string) (string, error) {
+func (*UtilsStruct) GetDataFromXHTML(dataSourceURLStruct types.DataSourceURL, selector string) (string, error) {
 	c := colly.NewCollector()
 	var priceData string
 	c.OnXML(selector, func(e *colly.XMLElement) {
 		priceData = e.Text
 	})
-	err := c.Visit(url)
+	err := c.Visit(dataSourceURLStruct.URL)
 	if err != nil {
 		return "", err
 	}

--- a/utils/api.go
+++ b/utils/api.go
@@ -1,39 +1,84 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
-	"net/http"
-	"time"
-
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/avast/retry-go"
 	"github.com/gocolly/colly"
+	"io/ioutil"
+	"net/http"
+	"razor/core/types"
+	"time"
 )
 
-func (*UtilsStruct) GetDataFromAPI(url string) ([]byte, error) {
+//'https://staging-v2.skalenodes.com/v1/whispering-turais  -X POST -H "Content-Type: application/json"}'
+//[]byte(`{"Type":1,"name":"test"}`
+func (*UtilsStruct) GetDataFromAPI(dataSourceURL string) ([]byte, error) {
 	client := http.Client{
 		Timeout: 10 * time.Second,
 	}
+
+	dataSourceURLInBytes := []byte(dataSourceURL)
+	var dataSourceURLStruct types.DataSourceURL
 	var body []byte
-	err := retry.Do(
-		func() error {
-			response, err := client.Get(url)
-			if err != nil {
-				return err
-			}
-			defer response.Body.Close()
-			if response.StatusCode != 200 {
-				log.Errorf("API: %s responded with status code %d", url, response.StatusCode)
-				return errors.New("unable to reach API")
-			}
-			body, err = IOInterface.ReadAll(response.Body)
-			if err != nil {
-				return err
-			}
-			return nil
-		}, retry.Attempts(2), retry.Delay(time.Second*2))
+
+	err := json.Unmarshal(dataSourceURLInBytes, &dataSourceURLStruct)
 	if err != nil {
-		return nil, err
+		log.Errorf("Error in unmarshalling %s: %v", dataSourceURL, err)
+		return body, err
+	}
+	log.Infof("URL Struct: %+v", dataSourceURLStruct)
+	if dataSourceURLStruct.Type == "GET" {
+		err := retry.Do(
+			func() error {
+				response, err := client.Get(dataSourceURLStruct.URL)
+				if err != nil {
+					return err
+				}
+				defer response.Body.Close()
+				if response.StatusCode != 200 {
+					log.Errorf("API: %s responded with status code %d", dataSourceURLStruct.URL, response.StatusCode)
+					return errors.New("unable to reach API")
+				}
+				body, err = IOInterface.ReadAll(response.Body)
+				if err != nil {
+					return err
+				}
+				return nil
+			}, retry.Attempts(2), retry.Delay(time.Second*2))
+		if err != nil {
+			return nil, err
+		}
+	}
+	if dataSourceURLStruct.Type == "POST" {
+		postBody, err := json.Marshal(dataSourceURLStruct.Body)
+		if err != nil {
+			log.Errorf("Error in marshalling body of a POST request URL %s: %v", dataSourceURLStruct.URL, err)
+		}
+		responseBody := bytes.NewBuffer(postBody)
+		err = retry.Do(
+			func() error {
+				response, err := client.Post(dataSourceURLStruct.URL, dataSourceURLStruct.ContentType, responseBody)
+				if err != nil {
+					log.Errorf("Error sending POST request URL %s: %v", dataSourceURLStruct.URL, err)
+					return err
+				}
+				defer response.Body.Close()
+				if response.StatusCode != 200 {
+					log.Errorf("URL: %s responded with status code %d", dataSourceURLStruct.URL, response.StatusCode)
+					return errors.New("unable to reach API")
+				}
+				body, err = ioutil.ReadAll(response.Body)
+				if err != nil {
+					return err
+				}
+				return nil
+			}, retry.Attempts(2), retry.Delay(time.Second*2))
+		if err != nil {
+			return nil, err
+		}
 	}
 	return body, nil
 }

--- a/utils/asset.go
+++ b/utils/asset.go
@@ -270,20 +270,29 @@ func (*UtilsStruct) GetDataToCommitFromJob(job bindings.StructsJob) (*big.Int, e
 		response []byte
 		apiErr   error
 	)
+	dataSourceURLInBytes := []byte(job.Url)
+	var dataSourceURLStruct types.DataSourceURL
 
+	err := json.Unmarshal(dataSourceURLInBytes, &dataSourceURLStruct)
+	if err != nil {
+		log.Errorf("Error in unmarshalling %s: %v", job.Url, err)
+		return nil, err
+	}
+	log.Infof("URL Struct: %+v", dataSourceURLStruct)
 	// Fetch data from API with retry mechanism
 	var parsedData interface{}
 	if job.SelectorType == 0 {
+
 		start := time.Now()
-		response, apiErr = UtilsInterface.GetDataFromAPI(job.Url)
+		response, apiErr = UtilsInterface.GetDataFromAPI(dataSourceURLStruct)
 		if apiErr != nil {
 			log.Error("Error in fetching data from API: ", apiErr)
 			return nil, apiErr
 		}
 		elapsed := time.Since(start).Seconds()
-		log.Debugf("Time taken to fetch the data from API : %s was %f", job.Url, elapsed)
+		log.Debugf("Time taken to fetch the data from API : %s was %f", dataSourceURLStruct.URL, elapsed)
 
-		err := json.Unmarshal(response, &parsedJSON)
+		err = json.Unmarshal(response, &parsedJSON)
 		if err != nil {
 			log.Error("Error in parsing data from API: ", err)
 			return nil, err
@@ -295,7 +304,7 @@ func (*UtilsStruct) GetDataToCommitFromJob(job bindings.StructsJob) (*big.Int, e
 		}
 	} else {
 		//TODO: Add retry here.
-		dataPoint, err := UtilsInterface.GetDataFromXHTML(job.Url, job.Selector)
+		dataPoint, err := UtilsInterface.GetDataFromXHTML(dataSourceURLStruct, job.Selector)
 		if err != nil {
 			log.Error("Error in fetching value from parsed XHTML: ", err)
 			return nil, err

--- a/utils/asset_test.go
+++ b/utils/asset_test.go
@@ -551,10 +551,10 @@ func TestGetDataToCommitFromJobs(t *testing.T) {
 	jobsArray := []bindings.StructsJob{
 		{Id: 1, SelectorType: 1, Weight: 100,
 			Power: 2, Name: "ethusd_gemini", Selector: "last",
-			Url: "https://api.gemini.com/v1/pubticker/ethusd",
+			Url: `{"type": "GET","url": "https://api.gemini.com/v1/pubticker/ethusd","body": {},"content-type": ""}`,
 		}, {Id: 2, SelectorType: 1, Weight: 100,
 			Power: 2, Name: "ethusd_gemini", Selector: "last",
-			Url: "https://api.gemini.com/v1/pubticker/ethusd",
+			Url: `{"type": "GET","url": "https://api.gemini.com/v1/pubticker/ethusd","body": {},"content-type": ""}`,
 		},
 	}
 
@@ -579,7 +579,7 @@ func TestGetDataToCommitFromJobs(t *testing.T) {
 				overrideJobData: map[string]*types.StructsJob{"1": {
 					Id: 2, SelectorType: 1, Weight: 100,
 					Power: 2, Name: "ethusd_gemini", Selector: "last",
-					Url: "https://api.gemini.com/v1/pubticker/ethusd",
+					Url: `{"type": "GET","url": "https://api.gemini.com/v1/pubticker/ethusd","body": {},"content-type": ""}`,
 				}},
 				dataToAppend: big.NewInt(1),
 			},
@@ -647,12 +647,12 @@ func TestGetDataToCommitFromJobs(t *testing.T) {
 func TestGetDataToCommitFromJob(t *testing.T) {
 	job := bindings.StructsJob{Id: 1, SelectorType: 1, Weight: 100,
 		Power: 2, Name: "ethusd_gemini", Selector: "last",
-		Url: "https://api.gemini.com/v1/pubticker/ethusd",
+		Url: `{"type": "GET","url": "https://api.gemini.com/v1/pubticker/ethusd","body": {},"content-type": ""}`,
 	}
 
 	job2 := bindings.StructsJob{Id: 1, SelectorType: 0, Weight: 100,
 		Power: 2, Name: "ethusd_gemini", Selector: "last",
-		Url: "https://api.gemini.com/v1/pubticker/ethusd",
+		Url: `{"type": "GET","url": "https://api.gemini.com/v1/pubticker/ethusd","body": {},"content-type": ""}`,
 	}
 
 	response := []byte(`{
@@ -785,9 +785,9 @@ func TestGetDataToCommitFromJob(t *testing.T) {
 			}
 			utils := StartRazor(optionsPackageStruct)
 
-			utilsMock.On("GetDataFromAPI", mock.AnythingOfType("string")).Return(tt.args.response, tt.args.responseErr)
+			utilsMock.On("GetDataFromAPI", mock.Anything).Return(tt.args.response, tt.args.responseErr)
 			utilsMock.On("GetDataFromJSON", mock.Anything, mock.AnythingOfType("string")).Return(tt.args.parsedData, tt.args.parsedDataErr)
-			utilsMock.On("GetDataFromXHTML", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(tt.args.dataPoint, tt.args.dataPointErr)
+			utilsMock.On("GetDataFromXHTML", mock.Anything, mock.AnythingOfType("string")).Return(tt.args.dataPoint, tt.args.dataPointErr)
 			utilsMock.On("ConvertToNumber", mock.Anything).Return(tt.args.datum, tt.args.datumErr)
 
 			got, err := utils.GetDataToCommitFromJob(tt.args.job)

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -128,10 +128,10 @@ type Utils interface {
 	GetJobs(client *ethclient.Client) ([]bindings.StructsJob, error)
 	GetAllCollections(client *ethclient.Client) ([]bindings.StructsCollection, error)
 	GetActiveCollectionIds(client *ethclient.Client) ([]uint16, error)
-	GetDataFromAPI(url string) ([]byte, error)
+	GetDataFromAPI(urlStruct types.DataSourceURL) ([]byte, error)
 	GetDataFromJSON(jsonObject map[string]interface{}, selector string) (interface{}, error)
 	HandleOfficialJobsFromJSONFile(client *ethclient.Client, collection bindings.StructsCollection, dataString string) ([]bindings.StructsJob, []uint16)
-	GetDataFromXHTML(url string, selector string) (string, error)
+	GetDataFromXHTML(urlStruct types.DataSourceURL, selector string) (string, error)
 	ConnectToClient(provider string) *ethclient.Client
 	FetchBalance(client *ethclient.Client, accountAddress string) (*big.Int, error)
 	GetBufferedState(client *ethclient.Client, buffer int32) (int64, error)

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -729,13 +729,13 @@ func (_m *Utils) GetCommitments(client *ethclient.Client, address string) ([32]b
 	return r0, r1
 }
 
-// GetDataFromAPI provides a mock function with given fields: url
-func (_m *Utils) GetDataFromAPI(url string) ([]byte, error) {
-	ret := _m.Called(url)
+// GetDataFromAPI provides a mock function with given fields: urlStruct
+func (_m *Utils) GetDataFromAPI(urlStruct types.DataSourceURL) ([]byte, error) {
+	ret := _m.Called(urlStruct)
 
 	var r0 []byte
-	if rf, ok := ret.Get(0).(func(string) []byte); ok {
-		r0 = rf(url)
+	if rf, ok := ret.Get(0).(func(types.DataSourceURL) []byte); ok {
+		r0 = rf(urlStruct)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -743,8 +743,8 @@ func (_m *Utils) GetDataFromAPI(url string) ([]byte, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(url)
+	if rf, ok := ret.Get(1).(func(types.DataSourceURL) error); ok {
+		r1 = rf(urlStruct)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -775,20 +775,20 @@ func (_m *Utils) GetDataFromJSON(jsonObject map[string]interface{}, selector str
 	return r0, r1
 }
 
-// GetDataFromXHTML provides a mock function with given fields: url, selector
-func (_m *Utils) GetDataFromXHTML(url string, selector string) (string, error) {
-	ret := _m.Called(url, selector)
+// GetDataFromXHTML provides a mock function with given fields: urlStruct, selector
+func (_m *Utils) GetDataFromXHTML(urlStruct types.DataSourceURL, selector string) (string, error) {
+	ret := _m.Called(urlStruct, selector)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(string, string) string); ok {
-		r0 = rf(url, selector)
+	if rf, ok := ret.Get(0).(func(types.DataSourceURL, string) string); ok {
+		r0 = rf(urlStruct, selector)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(url, selector)
+	if rf, ok := ret.Get(1).(func(types.DataSourceURL, string) error); ok {
+		r1 = rf(urlStruct, selector)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
# Description

Implemented Razor go support for change in `URL` field, which is now a string containing request details.
```
URL : `{
      type: "GET",
      url: "https://api.gemini.com/v1/pubticker/ethusd",
      body: {},
      content-type: ""
    }`
```
- Value to URL flag in `createJob` command should be passed with new format as shown in example below
```
--url {"type":"GET","url":"https://api.kraken.com/0/public/Ticker?pair=ETHUSD","body":{},"content-type":""}
```
- Assets.json for custom jobs format is updated now.
closes #1001
