### PR TITLE
Increased max size of log file to 182MB

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -54,7 +54,7 @@ func InitializeLogger(fileName string) {
 
 		lumberJackLogger := &lumberjack.Logger{
 			Filename:   logFilePath,
-			MaxSize:    105, // Maximum Size of a log file
+			MaxSize:    182, // Maximum Size of a log file
 			MaxBackups: 52,  // Maximum number of log files
 			MaxAge:     365, // Maximum number of days to retain olf files
 		}


### PR DESCRIPTION
# Description

A log file consumes upto 26 MB per day after the latest change (#1025) in `v1.0.5-alpha-patch1` release.

As we want 1 file per week, so for a week it would take `26*7 = 182MB`.

Fixes #1026

