### PR TITLE
Added sleep time to reduce amount of RPC calls to get blockNumber

### DIFF
--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -137,6 +137,7 @@ func (*UtilsStruct) Vote(ctx context.Context, config types.Configurations, clien
 				header = latestHeader
 				cmdUtils.HandleBlock(client, account, latestHeader.Number, config, rogueData, backupNodeActionsToIgnore)
 			}
+			time.Sleep(time.Second * time.Duration(core.BlockNumberInterval))
 		}
 	}
 }


### PR DESCRIPTION
# Description

Added sleep time between continuous RPC calls to get block Number to reduce the number of request calls.

Fixes #1041

