### PR TITLE
updated CI for dockerhub token.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: "Build docker image"
           command: |
-            echo "$DOCKERHUB_PASSWORD" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+            echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
             docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag $IMAGE_NAME:$CIRCLE_TAG .
   build-amd:
     machine:


### PR DESCRIPTION
# Description

Update CircleCI to use `DOCKERHUB_TOKEN` for docker login.
Fixes #1051 

