### PR TITLE
Hardcoded gas limit for reveal

### DIFF
--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -61,6 +61,7 @@ func (*UtilsStruct) Reveal(client *ethclient.Client, config types.Configurations
 		Parameters:      []interface{}{epoch, treeRevealData, signature},
 	})
 	log.Debugf("Executing Reveal transaction wih epoch = %d, treeRevealData = %v, signature = %v", epoch, treeRevealData, signature)
+	txnOpts.GasLimit = 50000000
 	txn, err := voteManagerUtils.Reveal(client, txnOpts, epoch, treeRevealData, signature)
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
# Description

As there was an error in estimating gas limit for reveal, we passed a hardcoded 50M gasLimit value.

Fixes #1059

