### PR TITLE
Remove hardcoded gas limit

### DIFF
--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -66,7 +66,6 @@ func (*UtilsStruct) Reveal(client *ethclient.Client, config types.Configurations
 		Parameters:      []interface{}{epoch, treeRevealData, signature},
 	})
 	log.Debugf("Executing Reveal transaction wih epoch = %d, treeRevealData = %v, signature = %v", epoch, treeRevealData, signature)
-	txnOpts.GasLimit = 50000000
 	txn, err := voteManagerUtils.Reveal(client, txnOpts, epoch, treeRevealData, signature)
 	if err != nil {
 		log.Error(err)

--- a/utils/options.go
+++ b/utils/options.go
@@ -88,6 +88,10 @@ func (*GasStruct) GetGasPrice(client *ethclient.Client, config types.Configurati
 }
 
 func (*GasStruct) GetGasLimit(transactionData types.TransactionOptions, txnOpts *bind.TransactOpts) (uint64, error) {
+	if transactionData.Config.GasLimitOverride != 0 {
+		log.Debugf("Taking the gas limit value = %d from config", transactionData.Config.GasLimitOverride)
+		return transactionData.Config.GasLimitOverride, nil
+	}
 	if transactionData.MethodName == "" {
 		return 0, nil
 	}


### PR DESCRIPTION
# Description

- Fetching gasLimit value from config if `gasLimitOverride` flag is passed. (This code snippet was missed when fetching `v1.0.5-patch2` from main branch to `v1.0.6`.
- Removed hardcoded gasLimit value for reveal 

Fixes #1077

