### PR TITLE
Revert "Reduced wait for block completion to 1 second"

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -91,7 +91,7 @@ func (*UtilsStruct) WaitForBlockCompletion(client *ethclient.Client, hashToRead 
 			log.Info("Transaction mined successfully")
 			return nil
 		}
-		Time.Sleep(time.Second)
+		Time.Sleep(3 * time.Second)
 	}
 	log.Info("Timeout Passed")
 	return errors.New("timeout passed for transaction mining")


### PR DESCRIPTION
This reverts commit b804122099123ffcdf3ac674254d7ab4c0c3f54b.

# Description
As we are not considering issue #843 anymore so there is no need of the respective change that was merged for `1.0.6` release.
This reverts PR #984 from the release `1.0.6`. 

