### PR TITLE
Fixed error log for commit transaction

### DIFF
--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -393,7 +393,7 @@ func (*UtilsStruct) InitiateCommit(client *ethclient.Client, config types.Config
 	if commitTxn != core.NilHash {
 		waitForBlockCompletionErr := razorUtils.WaitForBlockCompletion(client, commitTxn.Hex())
 		if waitForBlockCompletionErr != nil {
-			log.Error("Error in WaitForBlockCompletion for commit: ", err)
+			log.Error("Error in WaitForBlockCompletion for commit: ", waitForBlockCompletionErr)
 			return errors.New("error in sending commit transaction")
 		}
 		log.Debug("Updating GlobalCommitDataStruct with latest commitData and epoch...")


### PR DESCRIPTION
# Description

Changed `err` which was incorrect error to display  to `waitForBlockCompletionErr` in error log.

Fixes #1086

