### PR TITLE
Alternate provider fix

### DIFF
--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -133,7 +133,7 @@ func (*UtilsStruct) GetAlternateProvider() (string, error) {
 	}
 	if alternateProvider == "" {
 		if viper.IsSet("alternateProvider") {
-			alternateProvider = viper.GetString("alternatalternateProvider = viper.GetString(\"alternateProvidereProvider")
+			alternateProvider = viper.GetString("alternateProvider")
 		} else {
 			alternateProvider = ""
 			log.Debug("alternate provider is not set, taking its nil value ", alternateProvider)

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -129,14 +129,14 @@ func (*UtilsStruct) GetProvider() (string, error) {
 func (*UtilsStruct) GetAlternateProvider() (string, error) {
 	alternateProvider, err := flagSetUtils.GetRootStringAlternateProvider()
 	if err != nil {
-		return core.DefaultAlternateProvider, err
+		return "", err
 	}
 	if alternateProvider == "" {
 		if viper.IsSet("alternateProvider") {
-			alternateProvider = viper.GetString("alternateProvider")
+			alternateProvider = viper.GetString("alternatalternateProvider = viper.GetString(\"alternateProvidereProvider")
 		} else {
-			alternateProvider = core.DefaultAlternateProvider
-			log.Debug("alternate provider is not set, taking its default value ", alternateProvider)
+			alternateProvider = ""
+			log.Debug("alternate provider is not set, taking its nil value ", alternateProvider)
 		}
 	}
 	if !strings.HasPrefix(alternateProvider, "https") {

--- a/cmd/config-utils_test.go
+++ b/cmd/config-utils_test.go
@@ -676,7 +676,7 @@ func TestGetAlternateProvider(t *testing.T) {
 			args: args{
 				alternateProviderErr: errors.New("alternateProvider error"),
 			},
-			want:    "http://127.0.0.1:8545",
+			want:    "",
 			wantErr: errors.New("alternateProvider error"),
 		},
 		{
@@ -684,7 +684,7 @@ func TestGetAlternateProvider(t *testing.T) {
 			args: args{
 				alternateProvider: "",
 			},
-			want:    "http://127.0.0.1:8545",
+			want:    "",
 			wantErr: nil,
 		},
 	}

--- a/cmd/setConfig.go
+++ b/cmd/setConfig.go
@@ -165,7 +165,7 @@ func (*UtilsStruct) SetConfig(flagSet *pflag.FlagSet) error {
 	}
 	if provider == "" && alternateProvider == "" && gasMultiplier == -1 && bufferPercent == 0 && waitTime == -1 && gasPrice == -1 && logLevel == "" && gasLimit == -1 && gasLimitOverride == 0 && rpcTimeout == 0 && httpTimeout == 0 && logFileMaxSize == 0 && logFileMaxBackups == 0 && logFileMaxAge == 0 {
 		viper.Set("provider", core.DefaultProvider)
-		viper.Set("alternateProvider", core.DefaultAlternateProvider)
+		viper.Set("alternateProvider", "")
 		viper.Set("gasmultiplier", core.DefaultGasMultiplier)
 		viper.Set("buffer", core.DefaultBufferPercent)
 		viper.Set("wait", core.DefaultWaitTime)

--- a/core/constants.go
+++ b/core/constants.go
@@ -19,7 +19,6 @@ var BlockCompletionTimeout = 30
 //Following are the default config values for all the config parameters
 
 var DefaultProvider = "http://127.0.0.1:8545"
-var DefaultAlternateProvider = "http://127.0.0.1:8545"
 var DefaultGasMultiplier = 1.0
 var DefaultBufferPercent = 20
 var DefaultGasPrice = 1

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -120,8 +120,9 @@ func InvokeFunctionWithRetryAttempts(interfaceName interface{}, methodName strin
 	for i := range args {
 		inputs[i] = reflect.ValueOf(args[i])
 	}
+	alternateProvider := client.GetAlternateProvider()
 	switchToAlternateClient := client.GetSwitchToAlternateClientStatus()
-	if switchToAlternateClient {
+	if switchToAlternateClient && alternateProvider != "" {
 		// Changing client argument to alternate client
 		log.Debug("Making this RPC call using alternate RPC provider!")
 		inputs = client.ReplaceClientWithAlternateClient(inputs)
@@ -138,7 +139,7 @@ func InvokeFunctionWithRetryAttempts(interfaceName interface{}, methodName strin
 			return nil
 		}, RetryInterface.RetryAttempts(core.MaxRetries))
 	if err != nil {
-		if !switchToAlternateClient {
+		if !switchToAlternateClient && alternateProvider != "" {
 			log.Errorf("%v error after retries: %v", methodName, err)
 			log.Info("Switching RPC to alternate RPC")
 			client.SetSwitchToAlternateClientStatus(true)


### PR DESCRIPTION
# Description

Added a check whether `alternateProvder` is not set or equal to empty string before accessing feature of alternate provider.

Fixes #1091

