### PR TITLE
Returned error if provider is not set in config

### DIFF
--- a/cmd/config-utils_test.go
+++ b/cmd/config-utils_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"github.com/stretchr/testify/mock"
 	"razor/cmd/mocks"
 	"razor/core/types"
 	"reflect"
@@ -195,6 +196,7 @@ func TestGetConfigData(t *testing.T) {
 			cmdUtilsMock.On("GetLogFileMaxSize").Return(tt.args.logFileMaxSize, tt.args.logFileMaxSizeErr)
 			cmdUtilsMock.On("GetLogFileMaxBackups").Return(tt.args.logFileMaxBackups, tt.args.logFileMaxBackupsErr)
 			cmdUtilsMock.On("GetLogFileMaxAge").Return(tt.args.logFileMaxAge, tt.args.logFileMaxAgeErr)
+			utilsMock.On("IsFlagPassed", mock.AnythingOfType("string")).Return(true)
 			utils := &UtilsStruct{}
 
 			got, err := utils.GetConfigData()
@@ -608,7 +610,7 @@ func TestGetProvider(t *testing.T) {
 			args: args{
 				providerErr: errors.New("provider error"),
 			},
-			want:    "http://127.0.0.1:8545",
+			want:    "",
 			wantErr: errors.New("provider error"),
 		},
 		{
@@ -616,8 +618,8 @@ func TestGetProvider(t *testing.T) {
 			args: args{
 				provider: "",
 			},
-			want:    "http://127.0.0.1:8545",
-			wantErr: nil,
+			want:    "",
+			wantErr: errors.New("provider is not set"),
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"razor/logger"
 	"razor/path"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -99,38 +98,5 @@ func initConfig() {
 		} else {
 			log.Warn("error in reading config")
 		}
-	}
-
-	setLogLevel()
-}
-
-//This function sets the log level
-func setLogLevel() {
-	config, err := cmdUtils.GetConfigData()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if config.LogLevel == "debug" {
-		log.SetLevel(logrus.DebugLevel)
-	}
-
-	log.Debug("Config details: ")
-	log.Debugf("Provider: %s", config.Provider)
-	log.Debugf("Alternate Provider: %s", config.AlternateProvider)
-	log.Debugf("Gas Multiplier: %.2f", config.GasMultiplier)
-	log.Debugf("Buffer Percent: %d", config.BufferPercent)
-	log.Debugf("Wait Time: %d", config.WaitTime)
-	log.Debugf("Gas Price: %d", config.GasPrice)
-	log.Debugf("Log Level: %s", config.LogLevel)
-	log.Debugf("Gas Limit: %.2f", config.GasLimitMultiplier)
-	log.Debugf("Gas Limit Override: %d", config.GasLimitOverride)
-	log.Debugf("RPC Timeout: %d", config.RPCTimeout)
-	log.Debugf("HTTP Timeout: %d", config.HTTPTimeout)
-
-	if razorUtils.IsFlagPassed("logFile") {
-		log.Debugf("Log File Max Size: %d MB", config.LogFileMaxSize)
-		log.Debugf("Log File Max Backups (max number of old log files to retain): %d", config.LogFileMaxBackups)
-		log.Debugf("Log File Max Age (max number of days to retain old log files): %d", config.LogFileMaxAge)
 	}
 }

--- a/cmd/setConfig.go
+++ b/cmd/setConfig.go
@@ -164,7 +164,7 @@ func (*UtilsStruct) SetConfig(flagSet *pflag.FlagSet) error {
 		viper.Set("logFileMaxAge", logFileMaxAge)
 	}
 	if provider == "" && alternateProvider == "" && gasMultiplier == -1 && bufferPercent == 0 && waitTime == -1 && gasPrice == -1 && logLevel == "" && gasLimit == -1 && gasLimitOverride == 0 && rpcTimeout == 0 && httpTimeout == 0 && logFileMaxSize == 0 && logFileMaxBackups == 0 && logFileMaxAge == 0 {
-		viper.Set("provider", core.DefaultProvider)
+		viper.Set("provider", "")
 		viper.Set("alternateProvider", core.DefaultAlternateProvider)
 		viper.Set("gasmultiplier", core.DefaultGasMultiplier)
 		viper.Set("buffer", core.DefaultBufferPercent)

--- a/core/constants.go
+++ b/core/constants.go
@@ -18,7 +18,6 @@ var BlockCompletionTimeout = 30
 
 //Following are the default config values for all the config parameters
 
-var DefaultProvider = "http://127.0.0.1:8545"
 var DefaultAlternateProvider = "http://127.0.0.1:8545"
 var DefaultGasMultiplier = 1.0
 var DefaultBufferPercent = 20


### PR DESCRIPTION
# Description

- Shifted `setLogLevel()` from root.go to `GetConfigData()`
- Returned error if provider is not set in config
- Default provider as localhost is removed 

Fixes #1093

