### PR TITLE
Fetched `gasLimit` value from config if `estimateGas` fails

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -53,3 +53,6 @@ var BlockNumberInterval = 5
 
 //SwitchClientDuration is the time after which alternate client from secondary RPC will be switched back to client from primary RPC
 var SwitchClientDuration = 5 * EpochLength
+
+//HigherGasLimitValue is the gas limit which will be used when estimateGas fails
+var HigherGasLimitValue uint64 = 50000000

--- a/utils/client_methods.go
+++ b/utils/client_methods.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"context"
+	"github.com/avast/retry-go"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"math/big"
+	"razor/core"
 )
 
 func (*ClientStruct) GetNonceAtWithRetry(client *ethclient.Client, accountAddress common.Address) (uint64, error) {
@@ -27,19 +29,43 @@ func (*ClientStruct) GetLatestBlockWithRetry(client *ethclient.Client) (*types.H
 }
 
 func (*ClientStruct) SuggestGasPriceWithRetry(client *ethclient.Client) (*big.Int, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(ClientInterface, "SuggestGasPrice", client, context.Background())
+	var (
+		gasPrice *big.Int
+		err      error
+	)
+	err = retry.Do(
+		func() error {
+			gasPrice, err = ClientInterface.SuggestGasPrice(client, context.Background())
+			if err != nil {
+				log.Error("Error in fetching gas price.... Retrying")
+				return err
+			}
+			return nil
+		}, RetryInterface.RetryAttempts(core.MaxRetries))
 	if err != nil {
 		return nil, err
 	}
-	return returnedValues[0].Interface().(*big.Int), nil
+	return gasPrice, nil
 }
 
 func (*ClientStruct) EstimateGasWithRetry(client *ethclient.Client, message ethereum.CallMsg) (uint64, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(ClientInterface, "EstimateGas", client, context.Background(), message)
+	var (
+		gasLimit uint64
+		err      error
+	)
+	err = retry.Do(
+		func() error {
+			gasLimit, err = ClientInterface.EstimateGas(client, context.Background(), message)
+			if err != nil {
+				log.Error("Error in estimating gas limit.... Retrying")
+				return err
+			}
+			return nil
+		}, RetryInterface.RetryAttempts(core.MaxRetries))
 	if err != nil {
 		return 0, err
 	}
-	return returnedValues[0].Interface().(uint64), nil
+	return gasLimit, nil
 }
 
 func (*ClientStruct) FilterLogsWithRetry(client *ethclient.Client, query ethereum.FilterQuery) ([]types.Log, error) {

--- a/utils/options.go
+++ b/utils/options.go
@@ -118,6 +118,7 @@ func (*GasStruct) GetGasLimit(transactionData types.TransactionOptions, txnOpts 
 			log.Debugf("As there was an error from estimateGas, taking the gas limit value = %d from config", transactionData.Config.GasLimitOverride)
 			return transactionData.Config.GasLimitOverride, nil
 		}
+		log.Debugf("As there was an error from estimateGas, using the hardcoded higher gas limit value = %d", core.HigherGasLimitValue)
 		return core.HigherGasLimitValue, nil
 	}
 	log.Debug("Estimated Gas: ", gasLimit)

--- a/utils/options.go
+++ b/utils/options.go
@@ -88,10 +88,6 @@ func (*GasStruct) GetGasPrice(client *ethclient.Client, config types.Configurati
 }
 
 func (*GasStruct) GetGasLimit(transactionData types.TransactionOptions, txnOpts *bind.TransactOpts) (uint64, error) {
-	if transactionData.Config.GasLimitOverride != 0 {
-		log.Debugf("Taking the gas limit value = %d from config", transactionData.Config.GasLimitOverride)
-		return transactionData.Config.GasLimitOverride, nil
-	}
 	if transactionData.MethodName == "" {
 		return 0, nil
 	}
@@ -115,6 +111,12 @@ func (*GasStruct) GetGasLimit(transactionData types.TransactionOptions, txnOpts 
 	}
 	gasLimit, err := ClientInterface.EstimateGasWithRetry(transactionData.Client, msg)
 	if err != nil {
+		log.Error("GetGasLimit: Error in getting gasLimit: ", err)
+		//If estimateGas throws an error for a transaction than gasLimit should be picked up from the config
+		if transactionData.Config.GasLimitOverride != 0 {
+			log.Debugf("As there was an error from estimateGas, taking the gas limit value = %d from config", transactionData.Config.GasLimitOverride)
+			return transactionData.Config.GasLimitOverride, nil
+		}
 		return 0, err
 	}
 	log.Debug("Estimated Gas: ", gasLimit)

--- a/utils/options.go
+++ b/utils/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"razor/core"
 	"razor/core/types"
 	"strings"
 
@@ -117,7 +118,7 @@ func (*GasStruct) GetGasLimit(transactionData types.TransactionOptions, txnOpts 
 			log.Debugf("As there was an error from estimateGas, taking the gas limit value = %d from config", transactionData.Config.GasLimitOverride)
 			return transactionData.Config.GasLimitOverride, nil
 		}
-		return 0, err
+		return core.HigherGasLimitValue, nil
 	}
 	log.Debug("Estimated Gas: ", gasLimit)
 	return GasInterface.IncreaseGasLimitValue(transactionData.Client, gasLimit, transactionData.Config.GasLimitMultiplier)

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"math/big"
+	"razor/core"
 	"razor/core/types"
 	"razor/utils/mocks"
 	"reflect"
@@ -400,8 +401,8 @@ func TestUtilsStruct_GetGasLimit(t *testing.T) {
 				inputData:   inputData,
 				gasLimitErr: errors.New("gasLimit error"),
 			},
-			want:    0,
-			wantErr: errors.New("gasLimit error"),
+			want:    core.HigherGasLimitValue,
+			wantErr: nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

- if `EstimateGasWithRretry` fails, gasLimit is set as value of `gasLimitOverride` field from config. And if `gasLimitOverride` is not present in config, then gasLimit is set as `core.HigherGasLimit` from constants.go (50000000)
- Removed generic retry from `EstimateGasWithRetry` and `SuggestGasPriceWithRetry`

Fixes #1110
This is better way to avoid error #1059. 
