### PR TITLE
Replaced curve instance `elliptic.P256()` with `crypto.S256()` for random priv key for tests

### DIFF
--- a/cmd/addStake_test.go
+++ b/cmd/addStake_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -21,7 +21,7 @@ import (
 
 func TestStakeCoins(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	txnArgs := types.TransactionOptions{

--- a/cmd/addStake_test.go
+++ b/cmd/addStake_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -18,7 +21,7 @@ import (
 
 func TestStakeCoins(t *testing.T) {
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	txnArgs := types.TransactionOptions{

--- a/cmd/addStake_test.go
+++ b/cmd/addStake_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -21,7 +18,7 @@ import (
 
 func TestStakeCoins(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	txnArgs := types.TransactionOptions{

--- a/cmd/approve_test.go
+++ b/cmd/approve_test.go
@@ -2,9 +2,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -18,7 +15,7 @@ import (
 
 func TestApprove(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/approve_test.go
+++ b/cmd/approve_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -15,7 +18,7 @@ import (
 
 func TestApprove(t *testing.T) {
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/approve_test.go
+++ b/cmd/approve_test.go
@@ -3,12 +3,12 @@ package cmd
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	Types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/mock"
 	"math/big"
 	"razor/core"
@@ -18,7 +18,7 @@ import (
 
 func TestApprove(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"io/fs"
 	"math/big"
@@ -148,7 +145,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 }
 
 func TestClaimBounty(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"io/fs"
 	"math/big"
@@ -145,7 +148,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 }
 
 func TestClaimBounty(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"io/fs"
 	"math/big"
 	"razor/cmd/mocks"
@@ -148,7 +148,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 }
 
 func TestClaimBounty(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations

--- a/cmd/claimCommission_test.go
+++ b/cmd/claimCommission_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core/types"
@@ -19,7 +22,7 @@ func TestClaimCommission(t *testing.T) {
 	var flagSet *pflag.FlagSet
 	var callOpts bind.CallOpts
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {

--- a/cmd/claimCommission_test.go
+++ b/cmd/claimCommission_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"testing"
@@ -22,7 +22,7 @@ func TestClaimCommission(t *testing.T) {
 	var flagSet *pflag.FlagSet
 	var callOpts bind.CallOpts
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {

--- a/cmd/claimCommission_test.go
+++ b/cmd/claimCommission_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core/types"
@@ -22,7 +19,7 @@ func TestClaimCommission(t *testing.T) {
 	var flagSet *pflag.FlagSet
 	var callOpts bind.CallOpts
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -27,7 +24,7 @@ func TestCommit(t *testing.T) {
 		seed    []byte
 		epoch   uint32
 	)
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -24,7 +27,7 @@ func TestCommit(t *testing.T) {
 		seed    []byte
 		epoch   uint32
 	)
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	Types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/mock"
 	"math/big"
@@ -27,7 +27,7 @@ func TestCommit(t *testing.T) {
 		seed    []byte
 		epoch   uint32
 	)
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/confirm_test.go
+++ b/cmd/confirm_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"github.com/stretchr/testify/mock"
 	"math/big"
@@ -20,7 +17,7 @@ import (
 func TestClaimBlockReward(t *testing.T) {
 	var options types.TransactionOptions
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/confirm_test.go
+++ b/cmd/confirm_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/mock"
 	"math/big"
 	"razor/core"
@@ -20,7 +20,7 @@ import (
 func TestClaimBlockReward(t *testing.T) {
 	var options types.TransactionOptions
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/confirm_test.go
+++ b/cmd/confirm_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"github.com/stretchr/testify/mock"
 	"math/big"
@@ -17,7 +20,7 @@ import (
 func TestClaimBlockReward(t *testing.T) {
 	var options types.TransactionOptions
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/createCollection_test.go
+++ b/cmd/createCollection_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -17,7 +20,7 @@ import (
 
 func TestCreateCollection(t *testing.T) {
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/createCollection_test.go
+++ b/cmd/createCollection_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -20,7 +20,7 @@ import (
 
 func TestCreateCollection(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/createCollection_test.go
+++ b/cmd/createCollection_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -20,7 +17,7 @@ import (
 
 func TestCreateCollection(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/createJob_test.go
+++ b/cmd/createJob_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -23,7 +23,7 @@ func TestCreateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var config types.Configurations
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/createJob_test.go
+++ b/cmd/createJob_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -20,7 +23,7 @@ func TestCreateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var config types.Configurations
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/createJob_test.go
+++ b/cmd/createJob_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -23,7 +20,7 @@ func TestCreateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var config types.Configurations
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/delegate_test.go
+++ b/cmd/delegate_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -16,7 +19,7 @@ import (
 )
 
 func TestDelegate(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var stakerId uint32 = 1

--- a/cmd/delegate_test.go
+++ b/cmd/delegate_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestDelegate(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var stakerId uint32 = 1

--- a/cmd/delegate_test.go
+++ b/cmd/delegate_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -19,7 +16,7 @@ import (
 )
 
 func TestDelegate(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var stakerId uint32 = 1

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -19,7 +22,7 @@ import (
 )
 
 func TestDispute(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var (
@@ -120,7 +123,7 @@ func TestDispute(t *testing.T) {
 }
 
 func TestHandleDispute(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client
@@ -535,7 +538,7 @@ func TestHandleDispute(t *testing.T) {
 }
 
 func TestGiveSorted(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	nilDisputesMapping := types.DisputesStruct{
@@ -858,7 +861,7 @@ func TestCheckDisputeForIds(t *testing.T) {
 		blockIndex      uint8
 	)
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {
@@ -1139,7 +1142,7 @@ func BenchmarkGetCollectionIdPositionInBlock(b *testing.B) {
 }
 
 func BenchmarkHandleDispute(b *testing.B) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"io/fs"
 	"math/big"
 	"razor/core/types"
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDispute(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var (
@@ -123,7 +123,7 @@ func TestDispute(t *testing.T) {
 }
 
 func TestHandleDispute(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client
@@ -538,7 +538,7 @@ func TestHandleDispute(t *testing.T) {
 }
 
 func TestGiveSorted(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	nilDisputesMapping := types.DisputesStruct{
@@ -861,7 +861,7 @@ func TestCheckDisputeForIds(t *testing.T) {
 		blockIndex      uint8
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {
@@ -1142,7 +1142,7 @@ func BenchmarkGetCollectionIdPositionInBlock(b *testing.B) {
 }
 
 func BenchmarkHandleDispute(b *testing.B) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -22,7 +19,7 @@ import (
 )
 
 func TestDispute(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var (
@@ -123,7 +120,7 @@ func TestDispute(t *testing.T) {
 }
 
 func TestHandleDispute(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client
@@ -538,7 +535,7 @@ func TestHandleDispute(t *testing.T) {
 }
 
 func TestGiveSorted(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	nilDisputesMapping := types.DisputesStruct{
@@ -861,7 +858,7 @@ func TestCheckDisputeForIds(t *testing.T) {
 		blockIndex      uint8
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {
@@ -1142,7 +1139,7 @@ func BenchmarkGetCollectionIdPositionInBlock(b *testing.B) {
 }
 
 func BenchmarkHandleDispute(b *testing.B) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -14,7 +16,7 @@ import (
 
 func TestImportAccount(t *testing.T) {
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	var fileInfo fs.FileInfo
 
 	account := accounts.Account{Address: common.HexToAddress("0x000000000000000000000000000000000000dea1"),

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/mock"
 	"io/fs"
@@ -16,7 +16,7 @@ import (
 
 func TestImportAccount(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	var fileInfo fs.FileInfo
 
 	account := accounts.Account{Address: common.HexToAddress("0x000000000000000000000000000000000000dea1"),

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
@@ -16,7 +14,7 @@ import (
 
 func TestImportAccount(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	var fileInfo fs.FileInfo
 
 	account := accounts.Account{Address: common.HexToAddress("0x000000000000000000000000000000000000dea1"),

--- a/cmd/initiateWithdraw_test.go
+++ b/cmd/initiateWithdraw_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -19,7 +16,7 @@ import (
 )
 
 func TestHandleUnstakeLock(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client
@@ -220,7 +217,7 @@ func TestHandleUnstakeLock(t *testing.T) {
 }
 
 func TestWithdraw(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/initiateWithdraw_test.go
+++ b/cmd/initiateWithdraw_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestHandleUnstakeLock(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client
@@ -220,7 +220,7 @@ func TestHandleUnstakeLock(t *testing.T) {
 }
 
 func TestWithdraw(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/initiateWithdraw_test.go
+++ b/cmd/initiateWithdraw_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -16,7 +19,7 @@ import (
 )
 
 func TestHandleUnstakeLock(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client
@@ -217,7 +220,7 @@ func TestHandleUnstakeLock(t *testing.T) {
 }
 
 func TestWithdraw(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/modifyCollectionStatus_test.go
+++ b/cmd/modifyCollectionStatus_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -82,7 +79,7 @@ func TestCheckCurrentStatus(t *testing.T) {
 
 func TestModifyAssetStatus(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var config types.Configurations

--- a/cmd/modifyCollectionStatus_test.go
+++ b/cmd/modifyCollectionStatus_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -79,7 +82,7 @@ func TestCheckCurrentStatus(t *testing.T) {
 
 func TestModifyAssetStatus(t *testing.T) {
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var config types.Configurations

--- a/cmd/modifyCollectionStatus_test.go
+++ b/cmd/modifyCollectionStatus_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -82,7 +82,7 @@ func TestCheckCurrentStatus(t *testing.T) {
 
 func TestModifyAssetStatus(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var config types.Configurations

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
@@ -28,7 +31,7 @@ func TestPropose(t *testing.T) {
 		blockNumber *big.Int
 	)
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	salt := []byte{142, 170, 157, 83, 109, 43, 34, 152, 21, 154, 159, 12, 195, 119, 50, 186, 218, 57, 39, 173, 228, 135, 20, 100, 149, 27, 169, 158, 34, 113, 66, 64}

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"razor/pkg/bindings"
@@ -31,7 +31,7 @@ func TestPropose(t *testing.T) {
 		blockNumber *big.Int
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	salt := []byte{142, 170, 157, 83, 109, 43, 34, 152, 21, 154, 159, 12, 195, 119, 50, 186, 218, 57, 39, 173, 228, 135, 20, 100, 149, 27, 169, 158, 34, 113, 66, 64}

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
@@ -31,7 +28,7 @@ func TestPropose(t *testing.T) {
 		blockNumber *big.Int
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	salt := []byte{142, 170, 157, 83, 109, 43, 34, 152, 21, 154, 159, 12, 195, 119, 50, 186, 218, 57, 39, 173, 228, 135, 20, 100, 149, 27, 169, 158, 34, 113, 66, 64}

--- a/cmd/resetUnstakeLock_test.go
+++ b/cmd/resetUnstakeLock_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -17,7 +20,7 @@ import (
 
 func TestExtendLock(t *testing.T) {
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var extendLockInput types.ExtendLockInput

--- a/cmd/resetUnstakeLock_test.go
+++ b/cmd/resetUnstakeLock_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -20,7 +20,7 @@ import (
 
 func TestExtendLock(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var extendLockInput types.ExtendLockInput

--- a/cmd/resetUnstakeLock_test.go
+++ b/cmd/resetUnstakeLock_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -20,7 +17,7 @@ import (
 
 func TestExtendLock(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var extendLockInput types.ExtendLockInput

--- a/cmd/reveal_test.go
+++ b/cmd/reveal_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
@@ -96,7 +93,7 @@ func TestReveal(t *testing.T) {
 	var config types.Configurations
 	var epoch uint32
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/reveal_test.go
+++ b/cmd/reveal_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
@@ -93,7 +96,7 @@ func TestReveal(t *testing.T) {
 	var config types.Configurations
 	var epoch uint32
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/reveal_test.go
+++ b/cmd/reveal_test.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -96,7 +96,7 @@ func TestReveal(t *testing.T) {
 	var config types.Configurations
 	var epoch uint32
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/setDelegation_test.go
+++ b/cmd/setDelegation_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/cmd/mocks"
 	"razor/core"
@@ -31,7 +31,7 @@ func TestSetDelegation(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/setDelegation_test.go
+++ b/cmd/setDelegation_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/cmd/mocks"
@@ -28,7 +31,7 @@ func TestSetDelegation(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/setDelegation_test.go
+++ b/cmd/setDelegation_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/cmd/mocks"
@@ -31,7 +28,7 @@ func TestSetDelegation(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/test_utils.go
+++ b/cmd/test_utils.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"os"
-	"path/filepath"
-	"razor/accounts"
 	accountsPkgMocks "razor/accounts/mocks"
 	"razor/cmd/mocks"
 	"razor/path"
@@ -171,25 +167,4 @@ func SetUpMockInterfaces() {
 
 	accountsMock = new(accountsPkgMocks.AccountInterface)
 	accountUtils = accountsMock
-}
-
-func GetTestAccountPrivateKey() (*ecdsa.PrivateKey, error) {
-	testAccountAddress := "0xbd3e0a1d11163934df10501c9e1a18fbaa9ecaf4"
-	testAccountPassword := "Test@123"
-
-	accountUtils = accounts.AccountUtils{}
-	accounts.AccountUtilsInterface = accountUtils
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		log.Fatal("Error in getting the current directory for test account keystore:", err)
-	}
-	parentDir := filepath.Dir(currentDir)
-	testAccountPath := filepath.Join(parentDir, "utils/test_accounts")
-
-	privateKey, err := accountUtils.GetPrivateKey(testAccountAddress, testAccountPassword, testAccountPath)
-	if err != nil {
-		log.Fatal("Error in getting test account private key: ", err)
-	}
-	return privateKey, nil
 }

--- a/cmd/test_utils.go
+++ b/cmd/test_utils.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"os"
+	"path/filepath"
+	"razor/accounts"
 	accountsPkgMocks "razor/accounts/mocks"
 	"razor/cmd/mocks"
 	"razor/path"
@@ -167,4 +171,25 @@ func SetUpMockInterfaces() {
 
 	accountsMock = new(accountsPkgMocks.AccountInterface)
 	accountUtils = accountsMock
+}
+
+func GetTestAccountPrivateKey() (*ecdsa.PrivateKey, error) {
+	testAccountAddress := "0xbd3e0a1d11163934df10501c9e1a18fbaa9ecaf4"
+	testAccountPassword := "Test@123"
+
+	accountUtils = accounts.AccountUtils{}
+	accounts.AccountUtilsInterface = accountUtils
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal("Error in getting the current directory for test account keystore:", err)
+	}
+	parentDir := filepath.Dir(currentDir)
+	testAccountPath := filepath.Join(parentDir, "utils/test_accounts")
+
+	privateKey, err := accountUtils.GetPrivateKey(testAccountAddress, testAccountPassword, testAccountPath)
+	if err != nil {
+		log.Fatal("Error in getting test account private key: ", err)
+	}
+	return privateKey, nil
 }

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -23,7 +23,7 @@ func TestTransfer(t *testing.T) {
 	var client *ethclient.Client
 	var config types.Configurations
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31000))
 
 	type args struct {

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -23,7 +20,7 @@ func TestTransfer(t *testing.T) {
 	var client *ethclient.Client
 	var config types.Configurations
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31000))
 
 	type args struct {

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -20,7 +23,7 @@ func TestTransfer(t *testing.T) {
 	var client *ethclient.Client
 	var config types.Configurations
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31000))
 
 	type args struct {

--- a/cmd/unlockWithdraw_test.go
+++ b/cmd/unlockWithdraw_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -112,7 +115,7 @@ func TestExecuteUnlockWithdraw(t *testing.T) {
 }
 
 func TestHandleWithdrawLock(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var (

--- a/cmd/unlockWithdraw_test.go
+++ b/cmd/unlockWithdraw_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -115,7 +112,7 @@ func TestExecuteUnlockWithdraw(t *testing.T) {
 }
 
 func TestHandleWithdrawLock(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var (

--- a/cmd/unlockWithdraw_test.go
+++ b/cmd/unlockWithdraw_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -115,7 +115,7 @@ func TestExecuteUnlockWithdraw(t *testing.T) {
 }
 
 func TestHandleWithdrawLock(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var (

--- a/cmd/unstake_test.go
+++ b/cmd/unstake_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -18,7 +21,7 @@ import (
 )
 
 func TestUnstake(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations
@@ -323,7 +326,7 @@ func TestApproveUnstake(t *testing.T) {
 		txnArgs            types.TransactionOptions
 	)
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 	type args struct {
 		txn    *Types.Transaction

--- a/cmd/unstake_test.go
+++ b/cmd/unstake_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -21,7 +21,7 @@ import (
 )
 
 func TestUnstake(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations
@@ -326,7 +326,7 @@ func TestApproveUnstake(t *testing.T) {
 		txnArgs            types.TransactionOptions
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 	type args struct {
 		txn    *Types.Transaction

--- a/cmd/unstake_test.go
+++ b/cmd/unstake_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -21,7 +18,7 @@ import (
 )
 
 func TestUnstake(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations
@@ -326,7 +323,7 @@ func TestApproveUnstake(t *testing.T) {
 		txnArgs            types.TransactionOptions
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 	type args struct {
 		txn    *Types.Transaction

--- a/cmd/updateCollection_test.go
+++ b/cmd/updateCollection_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestUpdateCollection(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/updateCollection_test.go
+++ b/cmd/updateCollection_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -16,7 +19,7 @@ import (
 )
 
 func TestUpdateCollection(t *testing.T) {
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/updateCollection_test.go
+++ b/cmd/updateCollection_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -19,7 +16,7 @@ import (
 )
 
 func TestUpdateCollection(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"razor/pkg/bindings"
@@ -27,7 +27,7 @@ func TestUpdateCommission(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core/types"
@@ -27,7 +24,7 @@ func TestUpdateCommission(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core/types"
@@ -24,7 +27,7 @@ func TestUpdateCommission(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/updateJob_test.go
+++ b/cmd/updateJob_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -23,7 +26,7 @@ func TestUpdateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var jobId uint16
 
-	privateKey, _ := GetTestAccountPrivateKey()
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/updateJob_test.go
+++ b/cmd/updateJob_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -26,7 +26,7 @@ func TestUpdateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var jobId uint16
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/updateJob_test.go
+++ b/cmd/updateJob_test.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core"
@@ -26,7 +23,7 @@ func TestUpdateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var jobId uint16
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := GetTestAccountPrivateKey()
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core/types"
@@ -135,8 +137,8 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 	var transactionData types.TransactionOptions
 	var gasPrice *big.Int
 
-	privateKey := &ecdsa.PrivateKey{}
-	txnOpts := &bind.TransactOpts{}
+	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {
 		path            string

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -3,9 +3,9 @@ package utils
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"razor/utils/mocks"
@@ -137,7 +137,7 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 	var transactionData types.TransactionOptions
 	var gasPrice *big.Int
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -3,8 +3,6 @@ package utils
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"errors"
 	"math/big"
 	"razor/core/types"
@@ -137,8 +135,8 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 	var transactionData types.TransactionOptions
 	var gasPrice *big.Int
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
+	privateKey := &ecdsa.PrivateKey{}
+	txnOpts := &bind.TransactOpts{}
 
 	type args struct {
 		path            string


### PR DESCRIPTION
- Replaced curve instance `elliptic.P256()` with `crypto.S256()` in `ecdsa.GenerateKey()` for random priv key for tests

Fixes #1119

