### PR TITLE
updated oracle node version to `v1.0.7-alpha.1`

### DIFF
--- a/core/version.go
+++ b/core/version.go
@@ -3,10 +3,10 @@ package core
 import "fmt"
 
 const (
-	VersionMajor = 1       // Major version component of the current release
-	VersionMinor = 0       // Minor version component of the current release
-	VersionPatch = 7       // Patch version component of the current release
-	VersionMeta  = "alpha" // Version metadata to append to the version string
+	VersionMajor = 1         // Major version component of the current release
+	VersionMinor = 0         // Minor version component of the current release
+	VersionPatch = 7         // Patch version component of the current release
+	VersionMeta  = "alpha.1" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
- updated version to `v1.0.7-alpha.1` which will be our next alpha release