### PR TITLE
revert degrading go version to 1.19 for publish-github-release for ghr support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
 
   publish-github-release:
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.21.1
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/go:1.21.1
+      - image: cimg/go:1.21
     steps:
       - checkout
       - setup_remote_docker:
@@ -55,7 +55,7 @@ jobs:
             - .
   push-docker-build:
     docker:
-      - image: cimg/go:1.21.1
+      - image: cimg/go:1.21
         environment:
           IMAGE_NAME: "razornetwork/razor-go"
 
@@ -163,7 +163,7 @@ jobs:
 
   publish-github-release:
     docker:
-      - image: cimg/go:1.21.1
+      - image: cimg/go:1.17
     steps:
       - checkout
       - attach_workspace:
@@ -173,6 +173,7 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
+            go version
             go get -u github.com/tcnksm/ghr
             VERSION=$(git describe --tags --abbrev=0)
             mv razor_go.linux-amd64.tar.gz razor_go.${VERSION}.linux-amd64.tar.gz && mv razor_go.linux-arm64.tar.gz razor_go.${VERSION}.linux-arm64.tar.gz


### PR DESCRIPTION
# Description

Issue #1131 was not fixed by #1132 as it is throwing an error shown below: 
```
go: errors parsing go.mod:
/home/circleci/project/go.mod:3: invalid go version '1.21.1': must match format 1.23
```

This PR revert the same merge commit.
