### PR TITLE
Replaced `go1.21.1` to `go1.21` in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module razor
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
Fixes #1134