### PR TITLE
Replaced curve instance elliptic.P256() with crypto.S256() to ci work

### DIFF
--- a/cmd/addStake_test.go
+++ b/cmd/addStake_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -21,7 +21,7 @@ import (
 
 func TestStakeCoins(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	txnArgs := types.TransactionOptions{

--- a/cmd/approve_test.go
+++ b/cmd/approve_test.go
@@ -3,12 +3,12 @@ package cmd
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	Types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/mock"
 	"math/big"
 	"razor/core"
@@ -18,7 +18,7 @@ import (
 
 func TestApprove(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"io/fs"
 	"math/big"
 	"razor/cmd/mocks"
@@ -148,7 +148,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 }
 
 func TestClaimBounty(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations

--- a/cmd/claimCommission_test.go
+++ b/cmd/claimCommission_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"testing"
@@ -22,7 +22,7 @@ func TestClaimCommission(t *testing.T) {
 	var flagSet *pflag.FlagSet
 	var callOpts bind.CallOpts
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	Types "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/mock"
 	"math/big"
@@ -27,7 +27,7 @@ func TestCommit(t *testing.T) {
 		seed    []byte
 		epoch   uint32
 	)
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/confirm_test.go
+++ b/cmd/confirm_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/mock"
 	"math/big"
 	"razor/core"
@@ -20,7 +20,7 @@ import (
 func TestClaimBlockReward(t *testing.T) {
 	var options types.TransactionOptions
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/createCollection_test.go
+++ b/cmd/createCollection_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -20,7 +20,7 @@ import (
 
 func TestCreateCollection(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/createJob_test.go
+++ b/cmd/createJob_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -23,7 +23,7 @@ func TestCreateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var config types.Configurations
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/delegate_test.go
+++ b/cmd/delegate_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestDelegate(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var stakerId uint32 = 1

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"io/fs"
 	"math/big"
 	"razor/core/types"
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDispute(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var (
@@ -123,7 +123,7 @@ func TestDispute(t *testing.T) {
 }
 
 func TestHandleDispute(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client
@@ -538,7 +538,7 @@ func TestHandleDispute(t *testing.T) {
 }
 
 func TestGiveSorted(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	nilDisputesMapping := types.DisputesStruct{
@@ -861,7 +861,7 @@ func TestCheckDisputeForIds(t *testing.T) {
 		blockIndex      uint8
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	type args struct {
@@ -1142,7 +1142,7 @@ func BenchmarkGetCollectionIdPositionInBlock(b *testing.B) {
 }
 
 func BenchmarkHandleDispute(b *testing.B) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var client *ethclient.Client

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/mock"
 	"io/fs"
@@ -16,7 +16,7 @@ import (
 
 func TestImportAccount(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	var fileInfo fs.FileInfo
 
 	account := accounts.Account{Address: common.HexToAddress("0x000000000000000000000000000000000000dea1"),

--- a/cmd/initiateWithdraw_test.go
+++ b/cmd/initiateWithdraw_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestHandleUnstakeLock(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client
@@ -220,7 +220,7 @@ func TestHandleUnstakeLock(t *testing.T) {
 }
 
 func TestWithdraw(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/modifyCollectionStatus_test.go
+++ b/cmd/modifyCollectionStatus_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -82,7 +82,7 @@ func TestCheckCurrentStatus(t *testing.T) {
 
 func TestModifyAssetStatus(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var config types.Configurations

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"razor/pkg/bindings"
@@ -31,7 +31,7 @@ func TestPropose(t *testing.T) {
 		blockNumber *big.Int
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	salt := []byte{142, 170, 157, 83, 109, 43, 34, 152, 21, 154, 159, 12, 195, 119, 50, 186, 218, 57, 39, 173, 228, 135, 20, 100, 149, 27, 169, 158, 34, 113, 66, 64}

--- a/cmd/resetUnstakeLock_test.go
+++ b/cmd/resetUnstakeLock_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -20,7 +20,7 @@ import (
 
 func TestExtendLock(t *testing.T) {
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 
 	var extendLockInput types.ExtendLockInput

--- a/cmd/reveal_test.go
+++ b/cmd/reveal_test.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -96,7 +96,7 @@ func TestReveal(t *testing.T) {
 	var config types.Configurations
 	var epoch uint32
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/setDelegation_test.go
+++ b/cmd/setDelegation_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/cmd/mocks"
 	"razor/core"
@@ -31,7 +31,7 @@ func TestSetDelegation(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -23,7 +23,7 @@ func TestTransfer(t *testing.T) {
 	var client *ethclient.Client
 	var config types.Configurations
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31000))
 
 	type args struct {

--- a/cmd/unlockWithdraw_test.go
+++ b/cmd/unlockWithdraw_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -115,7 +115,7 @@ func TestExecuteUnlockWithdraw(t *testing.T) {
 }
 
 func TestHandleWithdrawLock(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var (

--- a/cmd/unstake_test.go
+++ b/cmd/unstake_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -21,7 +21,7 @@ import (
 )
 
 func TestUnstake(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var config types.Configurations
@@ -326,7 +326,7 @@ func TestApproveUnstake(t *testing.T) {
 		txnArgs            types.TransactionOptions
 	)
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(31337))
 	type args struct {
 		txn    *Types.Transaction

--- a/cmd/updateCollection_test.go
+++ b/cmd/updateCollection_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestUpdateCollection(t *testing.T) {
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	var client *ethclient.Client

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"razor/pkg/bindings"
@@ -27,7 +27,7 @@ func TestUpdateCommission(t *testing.T) {
 		WaitTime:      1,
 	}
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/cmd/updateJob_test.go
+++ b/cmd/updateJob_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core"
 	"razor/core/types"
@@ -26,7 +26,7 @@ func TestUpdateJob(t *testing.T) {
 	var jobInput types.CreateJobInput
 	var jobId uint16
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module razor
 
 go 1.21
 
-toolchain go1.21.3
-
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -3,9 +3,9 @@ package utils
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"errors"
+	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"razor/core/types"
 	"razor/utils/mocks"
@@ -137,7 +137,7 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 	var transactionData types.TransactionOptions
 	var gasPrice *big.Int
 
-	privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	txnOpts, _ := bind.NewKeyedTransactorWithChainID(privateKey, big.NewInt(1))
 
 	type args struct {


### PR DESCRIPTION
# Problem Statement

ci is failing for `develop` branch with error:
```
panic: crypto/elliptic: attempted operation on invalid point [recovered] panic: crypto/elliptic: attempted operation on invalid point
``` 

Closes https://linear.app/interstellar-research/issue/RAZ-466

# Solution
The PR changes the curve instance to `crypto.S256()` instead of `elliptic.P256()` to create dummy private keys.
```
privateKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
```
Changed it to -
```
privateKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
```