### PR TITLE
Set version meta to empty string

### DIFF
--- a/core/version.go
+++ b/core/version.go
@@ -3,10 +3,10 @@ package core
 import "fmt"
 
 const (
-	VersionMajor = 1     // Major version component of the current release
-	VersionMinor = 1     // Minor version component of the current release
-	VersionPatch = 0     // Patch version component of the current release
-	VersionMeta  = "dev" // Version metadata to append to the version string
+	VersionMajor = 1  // Major version component of the current release
+	VersionMinor = 1  // Minor version component of the current release
+	VersionPatch = 0  // Patch version component of the current release
+	VersionMeta  = "" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
# Description

Currently the version meta is `dev` on `develop` branch, this PR changes version meta to empty string.  

