### PR TITLE
Yash/raz 528 npm run build all fails with new update chainid script

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -11,7 +11,7 @@ var EpochLength uint64 = 1200
 var NumberOfStates uint64 = 5
 var StateLength = EpochLength / NumberOfStates
 
-// ChainId corresponds to the SKALE staging chain: staging-aware-chief-gianfar
+// ChainId corresponds to the SKALE chain
 var ChainId = big.NewInt(0x5a79c44e)
 
 var MaxRetries uint = 8

--- a/update-chainId.sh
+++ b/update-chainId.sh
@@ -13,5 +13,5 @@ else
     exit 1
 fi
 
-sed -i "s/var ChainId = big.NewInt(0x[a-fA-F0-9]*)/var ChainId = big.NewInt($CHAINID)/" core/constants.go
+sed -i '' "s/var ChainId = big.NewInt(0x[a-fA-F0-9]*)/var ChainId = big.NewInt($CHAINID)/" core/constants.go
 

--- a/update-chainId.sh
+++ b/update-chainId.sh
@@ -13,5 +13,12 @@ else
     exit 1
 fi
 
-sed -i '' "s/var ChainId = big.NewInt(0x[a-fA-F0-9]*)/var ChainId = big.NewInt($CHAINID)/" core/constants.go
+# Detect the OS and set the appropriate -i option
+if [ "$(uname)" = "Darwin" ]; then  # macOS
+    SED_I_OPTION=("-i" "")
+else  # GNU/Linux and others
+    SED_I_OPTION=("-i")
+fi
 
+# Use the correct option for sed based on the detected OS
+sed "${SED_I_OPTION[@]}" "s/var ChainId = big.NewInt(0x[a-fA-F0-9]*)/var ChainId = big.NewInt($CHAINID)/" core/constants.go


### PR DESCRIPTION
# Problem Statement
 [System os: macOS]
`npm run build-all` fails on `update-chainid.sh` script with error expecting input to `-i` option for stream editor `sed`.
The -i option expects an extension for in-place editing backup. On GNU/Linux, it's optional, but on macOS, it's mandatory.

Fixes: https://linear.app/interstellar-research/issue/RAZ-528

# Implementation

Created cases for input to `-i` in sed command for macOS and different os.

This PR also sync `develop` branch with `main` branch by fetching the updated commit from `main` branch.


# Testing
Ran all the build commands like `npm run build-all` which uses `update-chainId.sh` script. All of run them  fine with correct changes reflected. 