### PR TITLE
fix: update branch pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: CI/CD Release Pipeline
 on:
   push:
     branches:
-      - "release/*"
+      - "releases/*"
 
 jobs:
   test:


### PR DESCRIPTION
Problem: CI file would be triggered on pushes to release/*, but we need it to trigger on releases/*.

Solution: Renamed release/* to releases/*.

Testing: Not done, not needed.