### PR TITLE
fix: add rc to release workflow dockerhub tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,4 +93,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: razornetwork/razor-go:${{ steps.sha.outputs.short }}
+          tags: razornetwork/razor-go:rc-${{ steps.sha.outputs.short }}


### PR DESCRIPTION
- Problem: commit id when pushing a `releases/*` branch is the same as the develop dockerhub image tag created. 

- Solution: prefix the release.yml workflow to have `rc-${commit}`. This makes it unique, using the same commit id for the docker hub tag. Signifying that this is a internal mainnet release on docker.