### PR TITLE
fix: Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 ---
 name: CI/CD Pipeline
+
 on:
   push:
     tags:
@@ -14,42 +15,103 @@ on:
 permissions:
   contents: write
 
-
 jobs:
-  test:
+  setup-environment:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "18"
+
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.21
+
       - name: Install Dependencies
-        run: >
+        run: |
           sudo add-apt-repository -y ppa:ethereum/ethereum
-
           sudo apt-get update
-
           sudo apt-get install -y npm ethereum
-
           npm install
+          go get -d github.com/ethereum/go-ethereum@v1.12.2
+          go install github.com/ethereum/go-ethereum/cmd/abigen@v1.12.2
+          go install github.com/mattn/goveralls@v0.0.11
+          go install github.com/ory/go-acc@v0.2.7
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+        
+      - name: Cache Node modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-modules-
 
-          go get -d github.com/ethereum/go-ethereum@v1.12.2 \
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.OS }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.OS }}-go-mod-
 
-          && go install github.com/ethereum/go-ethereum/cmd/abigen@v1.12.2 \
+      - name: Create tarballs
+        run: |
+          mkdir bin && mv $(go env GOPATH)/bin/* bin/
+          tar -czf bin.tar.gz bin/
+          tar -czf node_modules.tar.gz node_modules/
 
-          && go install github.com/mattn/goveralls@v0.0.11 \
+      - name: Archive tarballs
+        uses: actions/upload-artifact@v2
+        with:
+          name: binaries
+          path: |
+            bin.tar.gz
+            node_modules.tar.gz
 
-          && go install github.com/ory/go-acc@v0.2.7 \
+  test:
+    needs: setup-environment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.21
 
-          && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Download Tarballs
+        uses: actions/download-artifact@v2
+        with:
+          name: binaries
+          path: ./
+
+      - name: Extract tarballs
+        run: |
+          tar -xzf bin.tar.gz 
+          tar -xzf node_modules.tar.gz
+
+      - name: Restore binaries
+        run: |
+         mv bin/* $(go env GOPATH)/bin/
+         chmod +x $(go env GOPATH)/bin/*
+
       - name: Run make setup for mainnet
         run: make setup
+
       - name: Run gofmt
         run: |
           gofmt
@@ -70,120 +132,64 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
-      - uses: bissolli/gh-action-persist-workspace@v1
-        with:
-          action: persist
 
-
-  build-amd:
+  build:
     runs-on: ubuntu-latest
-    needs: test
+    needs: 
+      - setup-environment
+      - test
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "18"
 
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.21
 
-      - name: Install Dependencies
-        run: >
-          sudo add-apt-repository -y ppa:ethereum/ethereum
-
-          sudo apt-get update
-
-          sudo apt-get install -y npm ethereum
-
-          npm install
-
-          go get -d github.com/ethereum/go-ethereum@v1.12.2 \
-
-          && go install github.com/ethereum/go-ethereum/cmd/abigen@v1.12.2 \
-
-          && go install github.com/mattn/goveralls@v0.0.11 \
-
-          && go install github.com/ory/go-acc@v0.2.7 \
-
-          && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
-
-      - name: Create AMD Artifact
-        run: |
-          # ... [commands to create AMD artifact]
-          make setup
-          GOOS=linux GOARCH=amd64 go build -o ./build/bin/razor_go.linux-amd64 main.go
-          cd build/bin
-          tar -czvf razor_go.linux-amd64.tar.gz razor_go.linux-amd64
-          mv razor_go.linux-amd64.tar.gz ../../
-
-      - name: Upload AMD Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: razor_go.linux-amd64.tar.gz
-          path: razor_go.linux-amd64.tar.gz
-  build-arm:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "18"
 
-      - name: Setup Go
-        uses: actions/setup-go@v2
+      - name: Download Tarballs
+        uses: actions/download-artifact@v2
         with:
-          go-version: 1.21
+          name: binaries
+          path: ./
 
-      - name: Install Dependencies
-        run: >
-          sudo add-apt-repository -y ppa:ethereum/ethereum
-
-          sudo apt-get update
-
-          sudo apt-get install -y npm ethereum
-
-          npm install
-
-          go get -d github.com/ethereum/go-ethereum@v1.12.2 \
-
-          && go install github.com/ethereum/go-ethereum/cmd/abigen@v1.12.2 \
-
-          && go install github.com/mattn/goveralls@v0.0.11 \
-
-          && go install github.com/ory/go-acc@v0.2.7 \
-
-          && go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
-
-      - name: Create ARM Artifact
+      - name: Extract tarballs
         run: |
-          # ... [commands to create ARM artifact]
-          make setup
-          GOOS=linux GOARCH=arm64 go build -o ./build/bin/razor_go.linux-arm64 main.go
-          cd build/bin
-          tar -czvf razor_go.linux-arm64.tar.gz razor_go.linux-arm64
-          mv razor_go.linux-arm64.tar.gz ../../
+          tar -xzf bin.tar.gz 
+          tar -xzf node_modules.tar.gz
 
-      - name: Upload ARM Artifact
+      - name: Restore binaries
+        run: |
+         mv bin/* $(go env GOPATH)/bin/
+         chmod +x $(go env GOPATH)/bin/*
+
+      - name: Create Artifact
+        run: |
+          make setup
+          GOOS=linux GOARCH=${{ matrix.arch }} go build -o ./build/bin/razor_go.linux-${{ matrix.arch }} main.go
+          cd build/bin
+          tar -czvf razor_go.linux-${{ matrix.arch }}.tar.gz razor_go.linux-${{ matrix.arch }}
+          mv razor_go.linux-${{ matrix.arch }}.tar.gz ../../
+
+      - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: razor_go.linux-arm64.tar.gz
-          path: razor_go.linux-arm64.tar.gz
+          name: razor_go.linux-${{ matrix.arch }}.tar.gz
+          path: razor_go.linux-${{ matrix.arch }}.tar.gz
 
 
   publish-github-release:
     runs-on: ubuntu-latest
     needs:
-      - build-amd
-      - build-arm
+      - build
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
           node-version: "18"
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: '1.21'
 
       - name: Install Dependencies
         run: |
@@ -84,9 +84,9 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: '1.21'
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -146,9 +146,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: '1.21'
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           node-version: "18"
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: '1.21'
       - name: Cache npm modules
         uses: actions/cache@v2
         with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -66,9 +66,6 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
-      - uses: bissolli/gh-action-persist-workspace@v1
-        with:
-          action: persist
 
   push-docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           node-version: "18"
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: '1.21'
       - name: Cache npm modules
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,9 +66,6 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: goveralls -coverprofile=coverage.txt -service=github
-      - uses: bissolli/gh-action-persist-workspace@v1
-        with:
-          action: persist
 
   push-docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,4 +93,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: razornetwork/razor-go:${{ steps.sha.outputs.short }}
+          tags: razornetwork/razor-go:rc-${{ steps.sha.outputs.short }}


### PR DESCRIPTION
Solutions: 

- Cache node and go modules, run install only once. This will reduce time taken by all jobs drastically. Code redundancy reduced.
- add `rc` to dockerhub tag used for release.yml (internal mainnet releases)
- keep single build job that uses matrix to create arm64 and amd64 builds. Code redundancy reduced.

CI is now more efficient: 
- Before: https://github.com/razor-network/oracle-node/actions/runs/6653119888
- After: https://github.com/razor-network/oracle-node/actions/runs/6743059702