### PR TITLE
feat: Implemented getIteration calculation concurrently in batches

### DIFF
--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -11,6 +11,7 @@ import (
 	"razor/pkg/bindings"
 	"razor/utils"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -252,7 +253,6 @@ loop:
 	return biggestStake, biggestStakerId, nil
 }
 
-//This function returns the iteration of the proposer if he is elected
 func (*UtilsStruct) GetIteration(client *ethclient.Client, proposer types.ElectedProposer, bufferPercent int32) int {
 	stake, err := razorUtils.GetStakeSnapshot(client, proposer.StakerId, proposer.Epoch)
 	if err != nil {
@@ -265,31 +265,75 @@ func (*UtilsStruct) GetIteration(client *ethclient.Client, proposer types.Electe
 	if err != nil {
 		return -1
 	}
-	stateTimeout := time.NewTimer(time.Second * time.Duration(stateRemainingTime))
 	log.Debug("GetIteration: State remaining time: ", stateRemainingTime)
+
+	stateTimeout := time.NewTimer(time.Second * time.Duration(stateRemainingTime))
+	wg := &sync.WaitGroup{}
+	wg.Add(core.NumRoutines)
+	done := make(chan bool, 10)
+	iterationResult := make(chan int, 10)
+	quit := make(chan bool, 10)
+
 	log.Debug("Calculating Iteration...")
-	log.Debugf("GetIteration: Calling IsElectedProposer() to find iteration...")
-loop:
-	for i := 0; i < 10000000; i++ {
-		select {
-		case <-stateTimeout.C:
-			log.Error("State timeout!")
-			break loop
-		default:
-			proposer.Iteration = i
-			isElected := cmdUtils.IsElectedProposer(proposer, currentStakerStake)
-			if isElected {
-				return i
+	for routine := 0; routine < core.NumRoutines; routine++ {
+		go getIterationConcurrently(proposer, currentStakerStake, routine, wg, done, iterationResult, quit, stateTimeout)
+	}
+
+	log.Debug("Waiting for all the goroutines to finish")
+	wg.Wait()
+	log.Debug("Done")
+
+	close(done)
+	close(quit)
+	close(iterationResult)
+
+	var iterations []int
+
+	for iteration := range iterationResult {
+		iterations = append(iterations, iteration)
+	}
+
+	sort.Ints(iterations)
+	return iterations[0]
+}
+
+func getIterationConcurrently(proposer types.ElectedProposer, currentStake *big.Int, routine int, wg *sync.WaitGroup, done chan bool, iterationResult chan int, quit chan bool, stateTimeout *time.Timer) {
+	//PARALLEL IMPLEMENTATION WITH BATCHES
+
+	defer wg.Done()
+	batchSize := core.BatchSize                  //1000
+	NumBatches := core.MaxIterations / batchSize //10000000/1000 = 10000
+	// Batch 0th - [0,1000)
+	// Batch 1th - [1000,2000)
+	for batch := 0; batch < NumBatches; batch++ {
+		for iteration := (batch * batchSize) + routine; iteration < (batch*batchSize)+batchSize; iteration = iteration + core.NumRoutines {
+			select {
+			case <-stateTimeout.C:
+				log.Error("getIterationConcurrently: State timeout!")
+				iterationResult <- -1
+				quit <- true
+				return
+			default:
+				proposer.Iteration = iteration
+				if len(done) >= 1 || len(quit) >= 1 {
+					return
+				}
+				isElected := cmdUtils.IsElectedProposer(proposer, currentStake)
+				if isElected {
+					iterationResult <- iteration
+					done <- true
+					return
+				}
 			}
 		}
 	}
-	return -1
+	iterationResult <- -1
+	log.Debug("IsElected is never true for this batch")
 }
 
 //This function returns if the elected staker is proposer or not
 func (*UtilsStruct) IsElectedProposer(proposer types.ElectedProposer, currentStakerStake *big.Int) bool {
 	seed := solsha3.SoliditySHA3([]string{"uint256"}, []interface{}{big.NewInt(int64(proposer.Iteration))})
-
 	pseudoRandomNumber := pseudoRandomNumberGenerator(seed, proposer.NumberOfStakers, proposer.Salt[:])
 	//add +1 since prng returns 0 to max-1 and staker start from 1
 	pseudoRandomNumber = pseudoRandomNumber.Add(pseudoRandomNumber, big.NewInt(1))

--- a/core/constants.go
+++ b/core/constants.go
@@ -66,3 +66,9 @@ var SwitchClientDuration = 5 * EpochLength
 
 // HexReturnType is the ReturnType for a job if that job returns a hex value
 var HexReturnType = "hex"
+
+// Following are the constants which helps in calculating iteration for a staker
+
+var BatchSize = 1000
+var NumRoutines = 10
+var MaxIterations = 10000000


### PR DESCRIPTION
# Description

Current GetIteration calculation takes time for larger iterations being O(n2), this PR implements the `GetIteration()` function concurrently.

Taking inspiration from our previous implementation of concurrent getIteration in one of our release : https://github.com/razor-network/oracle-node/pull/701

Fixes #https://linear.app/interstellar-research/issue/RAZ-600

# How Has This Been Tested?

Added suitable test cases with real data, and anaylsed existing benchmarks to check faster execution.

