### PR TITLE
feat: handled collections concurrently

### DIFF
--- a/core/types/assets.go
+++ b/core/types/assets.go
@@ -75,3 +75,8 @@ type DataSourceURL struct {
 	Header     map[string]string      `json:"header"`
 	ReturnType string                 `json:"returnType"`
 }
+
+type CollectionResult struct {
+	Index int
+	Leaf  *big.Int
+}

--- a/utils/asset.go
+++ b/utils/asset.go
@@ -165,7 +165,7 @@ func (*UtilsStruct) Aggregate(client *ethclient.Client, previousEpoch uint32, co
 		return nil, err
 	}
 	if _, err := path.OSUtilsInterface.Stat(assetsFilePath); !errors.Is(err, os.ErrNotExist) {
-		log.Debug("Fetching the jobs from assets.json file...")
+		log.Debugf("assets.json file is present, checking jobs for collection Id: %v...", collection.Id)
 		jsonFile, err := path.OSUtilsInterface.Open(assetsFilePath)
 		if err != nil {
 			return nil, err
@@ -191,13 +191,12 @@ func (*UtilsStruct) Aggregate(client *ethclient.Client, previousEpoch uint32, co
 		// Also adding custom jobs to jobs array
 		customJobs := GetCustomJobsFromJSONFile(collection.Name, dataString)
 		if len(customJobs) != 0 {
-			log.Debugf("Got Custom Jobs from asset.json file: %+v", customJobs)
+			log.Debugf("Got Custom Jobs from asset.json file for collectionId %v: %+v", collection.Id, customJobs)
 		}
 		jobs = append(jobs, customJobs...)
 	}
 
 	for _, id := range collection.JobIDs {
-
 		// Ignoring the Jobs which are already overriden and added to jobs array
 		if !Contains(overriddenJobIds, id) {
 			job, err := UtilsInterface.GetActiveJob(client, id)


### PR DESCRIPTION
# Description

Processed collections and its aggregated results concurrently.

Fixes https://linear.app/interstellar-research/issue/RAZ-691

# How Has This Been Tested?

Tested it on local setup with 5 min epoch and 10 collections present and `toAssign` set to 5. Calculates commitment correctly and does commit within shorter commit time successfuly. 