### PR TITLE
refactor: used a common http client for all the requests 

### DIFF
--- a/client/httpClient.go
+++ b/client/httpClient.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"net/http"
+	"razor/core"
 	"time"
 )
 
@@ -11,8 +12,8 @@ func InitHttpClient(httpTimeout int64) {
 	httpClient = &http.Client{
 		Timeout: time.Duration(httpTimeout) * time.Second,
 		Transport: &http.Transport{
-			MaxIdleConns:        5,
-			MaxIdleConnsPerHost: 5,
+			MaxIdleConns:        core.HTTPClientMaxIdleConns,
+			MaxIdleConnsPerHost: core.HTTPClientMaxIdleConnsPerHost,
 		},
 	}
 }

--- a/client/httpClient.go
+++ b/client/httpClient.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"net/http"
+	"time"
+)
+
+var httpClient *http.Client
+
+func InitHttpClient(httpTimeout int64) {
+	httpClient = &http.Client{
+		Timeout: time.Duration(httpTimeout) * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        5,
+			MaxIdleConnsPerHost: 5,
+		},
+	}
+}
+
+func GetHttpClient() *http.Client {
+	return httpClient
+}

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -99,7 +99,6 @@ func (*UtilsStruct) GetConfigData() (types.Configurations, error) {
 	config.RPCTimeout = rpcTimeout
 	utils.RPCTimeout = rpcTimeout
 	config.HTTPTimeout = httpTimeout
-	utils.HTTPTimeout = httpTimeout
 	config.LogFileMaxSize = logFileMaxSize
 	config.LogFileMaxBackups = logFileMaxBackups
 	config.LogFileMaxAge = logFileMaxAge

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"razor/accounts"
+	clientPkg "razor/client"
 	"razor/core"
 	"razor/core/types"
 	"razor/logger"
@@ -87,6 +88,8 @@ func (*UtilsStruct) ExecuteVote(flagSet *pflag.FlagSet) {
 	}
 
 	account := types.Account{Address: address, Password: password}
+
+	clientPkg.InitHttpClient(config.HTTPTimeout)
 
 	cmdUtils.HandleExit()
 

--- a/core/constants.go
+++ b/core/constants.go
@@ -86,3 +86,8 @@ var MaxIterations = 10000000
 
 var AssetUpdateListenerInterval = 10
 var AssetCacheExpiry = 5 * EpochLength
+
+// Following are the constants used in custom http.Transport configuration for the common HTTP client that we use for all the requests
+
+var HTTPClientMaxIdleConns = 15
+var HTTPClientMaxIdleConnsPerHost = 5

--- a/utils/api.go
+++ b/utils/api.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"razor/cache"
+	clientPkg "razor/client"
 	"razor/core"
 	"regexp"
 	"time"
@@ -20,10 +21,6 @@ import (
 )
 
 func GetDataFromAPI(dataSourceURLStruct types.DataSourceURL, localCache *cache.LocalCache) ([]byte, error) {
-	client := http.Client{
-		Timeout: time.Duration(HTTPTimeout) * time.Second,
-	}
-
 	cacheKey, err := generateCacheKey(dataSourceURLStruct.URL, dataSourceURLStruct.Body)
 	if err != nil {
 		log.Errorf("Error in generating cache key for API %s: %v", dataSourceURLStruct.URL, err)
@@ -36,7 +33,7 @@ func GetDataFromAPI(dataSourceURLStruct types.DataSourceURL, localCache *cache.L
 		return cachedData, nil
 	}
 
-	response, err := makeAPIRequest(client, dataSourceURLStruct)
+	response, err := makeAPIRequest(dataSourceURLStruct)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +43,7 @@ func GetDataFromAPI(dataSourceURLStruct types.DataSourceURL, localCache *cache.L
 	return response, nil
 }
 
-func makeAPIRequest(client http.Client, dataSourceURLStruct types.DataSourceURL) ([]byte, error) {
+func makeAPIRequest(dataSourceURLStruct types.DataSourceURL) ([]byte, error) {
 	var requestBody io.Reader // Using the broader io.Reader interface here
 
 	switch dataSourceURLStruct.Type {
@@ -68,7 +65,7 @@ func makeAPIRequest(client http.Client, dataSourceURLStruct types.DataSourceURL)
 	var response []byte
 	err := retry.Do(
 		func() error {
-			responseBody, err := ProcessRequest(client, dataSourceURLStruct, requestBody)
+			responseBody, err := ProcessRequest(dataSourceURLStruct, requestBody)
 			if err != nil {
 				log.Errorf("Error in processing %s request: %v", dataSourceURLStruct.Type, err)
 				return err
@@ -124,13 +121,14 @@ func addHeaderToRequest(request *http.Request, headerMap map[string]string) *htt
 	return request
 }
 
-func ProcessRequest(client http.Client, dataSourceURLStruct types.DataSourceURL, requestBody io.Reader) ([]byte, error) {
+func ProcessRequest(dataSourceURLStruct types.DataSourceURL, requestBody io.Reader) ([]byte, error) {
+	httpClient := clientPkg.GetHttpClient()
 	request, err := http.NewRequest(dataSourceURLStruct.Type, dataSourceURLStruct.URL, requestBody)
 	if err != nil {
 		return nil, err
 	}
 	requestWithHeader := addHeaderToRequest(request, dataSourceURLStruct.Header)
-	response, err := client.Do(requestWithHeader)
+	response, err := httpClient.Do(requestWithHeader)
 	if err != nil {
 		log.Errorf("Error sending %s request URL %s: %v", dataSourceURLStruct.Type, dataSourceURLStruct.URL, err)
 		return nil, err

--- a/utils/api_test.go
+++ b/utils/api_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/hex"
 	"razor/cache"
+	clientPkg "razor/client"
 	"razor/core/types"
 	"reflect"
 	"testing"
@@ -164,6 +165,7 @@ func TestGetDataFromAPI(t *testing.T) {
 			wantErr: true,
 		},
 	}
+	clientPkg.InitHttpClient(10)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			localCache := cache.NewLocalCache(time.Second * 10)

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -81,7 +81,7 @@ func InvokeFunctionWithTimeout(interfaceName interface{}, methodName string, arg
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
-					errChan <- errors.New(fmt.Sprintf("panic during function call: %v", r))
+					errChan <- fmt.Errorf("panic during function call: %v", r)
 				}
 			}()
 			result = reflect.ValueOf(interfaceName).MethodByName(methodName).Call(inputs)


### PR DESCRIPTION
# Description

Used a common http client to avoid opening a new connection on every `client.Do()` call for every API.
A single http client makes the node to reuse the existing connections from connection pool.

Fixes #1197 ,  https://linear.app/interstellar-research/issue/RAZ-771

# How Has This Been Tested?

Ran a node on local and staging environment with 5 min epoch time.