### PR TITLE
refactor: Optimised number of `GetBlockNumber` and `GetStakerId` eth calls

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -32,9 +32,9 @@ func CalculateLatestBlock(client *ethclient.Client) {
 			latestHeader, err := client.HeaderByNumber(context.Background(), nil)
 			if err != nil {
 				logrus.Error("CalculateBlockNumber: Error in fetching block: ", err)
-				continue
+			} else {
+				SetLatestBlock(latestHeader)
 			}
-			SetLatestBlock(latestHeader)
 		}
 		time.Sleep(time.Second * time.Duration(core.BlockNumberInterval))
 	}

--- a/cmd/cmd-utils.go
+++ b/cmd/cmd-utils.go
@@ -23,7 +23,12 @@ func (*UtilsStruct) GetEpochAndState(client *ethclient.Client) (uint32, int64, e
 	if err != nil {
 		return 0, 0, err
 	}
-	state, err := razorUtils.GetBufferedState(client, bufferPercent)
+	latestHeader, err := clientUtils.GetLatestBlockWithRetry(client)
+	if err != nil {
+		log.Error("Error in fetching block: ", err)
+		return 0, 0, err
+	}
+	state, err := razorUtils.GetBufferedState(client, latestHeader, bufferPercent)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"encoding/hex"
 	"errors"
+	Types "github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"razor/cache"
 	"razor/client"
@@ -150,8 +151,8 @@ func (*UtilsStruct) HandleCommitState(client *ethclient.Client, epoch uint32, se
 /*
 Commit finally commits the data to the smart contract. It calculates the commitment to send using the merkle tree root and the seed.
 */
-func (*UtilsStruct) Commit(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, seed []byte, values []*big.Int) (common.Hash, error) {
-	if state, err := razorUtils.GetBufferedState(client, config.BufferPercent); err != nil || state != 0 {
+func (*UtilsStruct) Commit(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, latestHeader *Types.Header, seed []byte, values []*big.Int) (common.Hash, error) {
+	if state, err := razorUtils.GetBufferedState(client, latestHeader, config.BufferPercent); err != nil || state != 0 {
 		log.Error("Not commit state")
 		return core.NilHash, err
 	}

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -20,11 +20,12 @@ import (
 
 func TestCommit(t *testing.T) {
 	var (
-		client  *ethclient.Client
-		account types.Account
-		config  types.Configurations
-		seed    []byte
-		epoch   uint32
+		client       *ethclient.Client
+		account      types.Account
+		config       types.Configurations
+		latestHeader *Types.Header
+		seed         []byte
+		epoch        uint32
 	)
 
 	type args struct {
@@ -95,13 +96,13 @@ func TestCommit(t *testing.T) {
 			utils.MerkleInterface = &utils.MerkleTreeStruct{}
 			merkleUtils = utils.MerkleInterface
 
-			utilsMock.On("GetBufferedState", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("int32")).Return(tt.args.state, tt.args.stateErr)
+			utilsMock.On("GetBufferedState", mock.AnythingOfType("*ethclient.Client"), mock.Anything, mock.Anything).Return(tt.args.state, tt.args.stateErr)
 			utilsMock.On("GetTxnOpts", mock.AnythingOfType("types.TransactionOptions")).Return(TxnOpts)
 			voteManagerMock.On("Commit", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("*bind.TransactOpts"), mock.AnythingOfType("uint32"), mock.Anything).Return(tt.args.commitTxn, tt.args.commitErr)
 			transactionMock.On("Hash", mock.AnythingOfType("*types.Transaction")).Return(tt.args.hash)
 
 			utils := &UtilsStruct{}
-			got, err := utils.Commit(client, config, account, epoch, seed, tt.args.values)
+			got, err := utils.Commit(client, config, account, epoch, latestHeader, seed, tt.args.values)
 			if got != tt.want {
 				t.Errorf("Txn hash for Commit function, got = %v, want = %v", got, tt.want)
 			}

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -232,9 +232,9 @@ type UtilsCmdInterface interface {
 	GetSmallestStakeAndId(client *ethclient.Client, epoch uint32) (*big.Int, uint32, error)
 	StakeCoins(txnArgs types.TransactionOptions) (common.Hash, error)
 	CalculateSecret(account types.Account, epoch uint32, keystorePath string, chainId *big.Int) ([]byte, []byte, error)
-	HandleBlock(client *ethclient.Client, account types.Account, blockNumber *big.Int, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string)
+	HandleBlock(client *ethclient.Client, account types.Account, stakerId uint32, blockNumber *big.Int, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string)
 	ExecuteVote(flagSet *pflag.FlagSet)
-	Vote(ctx context.Context, config types.Configurations, client *ethclient.Client, account types.Account, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) error
+	Vote(ctx context.Context, config types.Configurations, client *ethclient.Client, account types.Account, stakerId uint32, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) error
 	HandleExit()
 	ExecuteListAccounts(flagSet *pflag.FlagSet)
 	ClaimCommission(flagSet *pflag.FlagSet)

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -166,13 +166,13 @@ type UtilsCmdInterface interface {
 	ClaimBlockReward(options types.TransactionOptions) (common.Hash, error)
 	GetSalt(client *ethclient.Client, epoch uint32) ([32]byte, error)
 	HandleCommitState(client *ethclient.Client, epoch uint32, seed []byte, httpClient *client.HttpClient, rogueData types.Rogue) (types.CommitData, error)
-	Commit(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, seed []byte, values []*big.Int) (common.Hash, error)
+	Commit(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, latestHeader *Types.Header, seed []byte, values []*big.Int) (common.Hash, error)
 	ListAccounts() ([]accounts.Account, error)
 	AssignAmountInWei(flagSet *pflag.FlagSet) (*big.Int, error)
 	ExecuteTransfer(flagSet *pflag.FlagSet)
 	Transfer(client *ethclient.Client, config types.Configurations, transferInput types.TransferInput) (common.Hash, error)
 	CheckForLastCommitted(client *ethclient.Client, staker bindings.StructsStaker, epoch uint32) error
-	Reveal(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, commitData types.CommitData, signature []byte) (common.Hash, error)
+	Reveal(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, latestHeader *Types.Header, commitData types.CommitData, signature []byte) (common.Hash, error)
 	GenerateTreeRevealData(merkleTree [][][]byte, commitData types.CommitData) bindings.StructsMerkleTree
 	IndexRevealEventsOfCurrentEpoch(client *ethclient.Client, blockNumber *big.Int, epoch uint32) ([]types.RevealedStruct, error)
 	ExecuteCreateJob(flagSet *pflag.FlagSet)
@@ -207,7 +207,7 @@ type UtilsCmdInterface interface {
 	IsElectedProposer(proposer types.ElectedProposer, currentStakerStake *big.Int) bool
 	GetSortedRevealedValues(client *ethclient.Client, blockNumber *big.Int, epoch uint32) (*types.RevealedDataMaps, error)
 	GetIteration(client *ethclient.Client, proposer types.ElectedProposer, bufferPercent int32) int
-	Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error
+	Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, latestHeader *Types.Header, rogueData types.Rogue) error
 	GiveSorted(client *ethclient.Client, blockManager *bindings.BlockManager, txnArgs types.TransactionOptions, epoch uint32, assetId uint16, sortedStakers []*big.Int) error
 	GetLocalMediansData(client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) (types.ProposeFileData, error)
 	CheckDisputeForIds(client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*Types.Transaction, error)
@@ -232,16 +232,16 @@ type UtilsCmdInterface interface {
 	GetSmallestStakeAndId(client *ethclient.Client, epoch uint32) (*big.Int, uint32, error)
 	StakeCoins(txnArgs types.TransactionOptions) (common.Hash, error)
 	CalculateSecret(account types.Account, epoch uint32, keystorePath string, chainId *big.Int) ([]byte, []byte, error)
-	HandleBlock(client *ethclient.Client, account types.Account, stakerId uint32, blockNumber *big.Int, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string)
+	HandleBlock(client *ethclient.Client, account types.Account, stakerId uint32, header *Types.Header, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string)
 	ExecuteVote(flagSet *pflag.FlagSet)
 	Vote(ctx context.Context, config types.Configurations, client *ethclient.Client, account types.Account, stakerId uint32, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) error
 	HandleExit()
 	ExecuteListAccounts(flagSet *pflag.FlagSet)
 	ClaimCommission(flagSet *pflag.FlagSet)
 	ExecuteStake(flagSet *pflag.FlagSet)
-	InitiateCommit(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, stakerId uint32, httpClient *client.HttpClient, rogueData types.Rogue) error
-	InitiateReveal(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, rogueData types.Rogue) error
-	InitiatePropose(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, blockNumber *big.Int, rogueData types.Rogue) error
+	InitiateCommit(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, stakerId uint32, latestHeader *Types.Header, httpClient *client.HttpClient, rogueData types.Rogue) error
+	InitiateReveal(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, latestHeader *Types.Header, rogueData types.Rogue) error
+	InitiatePropose(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, latestHeader *Types.Header, rogueData types.Rogue) error
 	GetBountyIdFromEvents(client *ethclient.Client, blockNumber *big.Int, bountyHunter string) (uint32, error)
 	HandleClaimBounty(client *ethclient.Client, config types.Configurations, account types.Account) error
 	ExecuteContractAddresses(flagSet *pflag.FlagSet)

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -1191,9 +1191,9 @@ func (_m *UtilsCmdInterface) GiveSorted(_a0 *ethclient.Client, blockManager *bin
 	return r0
 }
 
-// HandleBlock provides a mock function with given fields: _a0, account, blockNumber, config, httpClient, rogueData, backupNodeActionsToIgnore
-func (_m *UtilsCmdInterface) HandleBlock(_a0 *ethclient.Client, account types.Account, blockNumber *big.Int, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) {
-	_m.Called(_a0, account, blockNumber, config, httpClient, rogueData, backupNodeActionsToIgnore)
+// HandleBlock provides a mock function with given fields: _a0, account, stakerId, blockNumber, config, httpClient, rogueData, backupNodeActionsToIgnore
+func (_m *UtilsCmdInterface) HandleBlock(_a0 *ethclient.Client, account types.Account, stakerId uint32, blockNumber *big.Int, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) {
+	_m.Called(_a0, account, stakerId, blockNumber, config, httpClient, rogueData, backupNodeActionsToIgnore)
 }
 
 // HandleClaimBounty provides a mock function with given fields: _a0, config, account
@@ -1828,13 +1828,13 @@ func (_m *UtilsCmdInterface) UpdateJob(_a0 *ethclient.Client, config types.Confi
 	return r0, r1
 }
 
-// Vote provides a mock function with given fields: ctx, config, _a2, account, httpClient, rogueData, backupNodeActionsToIgnore
-func (_m *UtilsCmdInterface) Vote(ctx context.Context, config types.Configurations, _a2 *ethclient.Client, account types.Account, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) error {
-	ret := _m.Called(ctx, config, _a2, account, httpClient, rogueData, backupNodeActionsToIgnore)
+// Vote provides a mock function with given fields: ctx, config, _a2, account, stakerId, httpClient, rogueData, backupNodeActionsToIgnore
+func (_m *UtilsCmdInterface) Vote(ctx context.Context, config types.Configurations, _a2 *ethclient.Client, account types.Account, stakerId uint32, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) error {
+	ret := _m.Called(ctx, config, _a2, account, stakerId, httpClient, rogueData, backupNodeActionsToIgnore)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, types.Configurations, *ethclient.Client, types.Account, *client.HttpClient, types.Rogue, []string) error); ok {
-		r0 = rf(ctx, config, _a2, account, httpClient, rogueData, backupNodeActionsToIgnore)
+	if rf, ok := ret.Get(0).(func(context.Context, types.Configurations, *ethclient.Client, types.Account, uint32, *client.HttpClient, types.Rogue, []string) error); ok {
+		r0 = rf(ctx, config, _a2, account, stakerId, httpClient, rogueData, backupNodeActionsToIgnore)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -272,25 +272,25 @@ func (_m *UtilsCmdInterface) ClaimCommission(flagSet *pflag.FlagSet) {
 	_m.Called(flagSet)
 }
 
-// Commit provides a mock function with given fields: _a0, config, account, epoch, seed, values
-func (_m *UtilsCmdInterface) Commit(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, seed []byte, values []*big.Int) (common.Hash, error) {
-	ret := _m.Called(_a0, config, account, epoch, seed, values)
+// Commit provides a mock function with given fields: _a0, config, account, epoch, latestHeader, seed, values
+func (_m *UtilsCmdInterface) Commit(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, latestHeader *coretypes.Header, seed []byte, values []*big.Int) (common.Hash, error) {
+	ret := _m.Called(_a0, config, account, epoch, latestHeader, seed, values)
 
 	var r0 common.Hash
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, []byte, []*big.Int) (common.Hash, error)); ok {
-		return rf(_a0, config, account, epoch, seed, values)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, *coretypes.Header, []byte, []*big.Int) (common.Hash, error)); ok {
+		return rf(_a0, config, account, epoch, latestHeader, seed, values)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, []byte, []*big.Int) common.Hash); ok {
-		r0 = rf(_a0, config, account, epoch, seed, values)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, *coretypes.Header, []byte, []*big.Int) common.Hash); ok {
+		r0 = rf(_a0, config, account, epoch, latestHeader, seed, values)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Hash)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, types.Configurations, types.Account, uint32, []byte, []*big.Int) error); ok {
-		r1 = rf(_a0, config, account, epoch, seed, values)
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, types.Configurations, types.Account, uint32, *coretypes.Header, []byte, []*big.Int) error); ok {
+		r1 = rf(_a0, config, account, epoch, latestHeader, seed, values)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1191,9 +1191,9 @@ func (_m *UtilsCmdInterface) GiveSorted(_a0 *ethclient.Client, blockManager *bin
 	return r0
 }
 
-// HandleBlock provides a mock function with given fields: _a0, account, stakerId, blockNumber, config, httpClient, rogueData, backupNodeActionsToIgnore
-func (_m *UtilsCmdInterface) HandleBlock(_a0 *ethclient.Client, account types.Account, stakerId uint32, blockNumber *big.Int, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) {
-	_m.Called(_a0, account, stakerId, blockNumber, config, httpClient, rogueData, backupNodeActionsToIgnore)
+// HandleBlock provides a mock function with given fields: _a0, account, stakerId, header, config, httpClient, rogueData, backupNodeActionsToIgnore
+func (_m *UtilsCmdInterface) HandleBlock(_a0 *ethclient.Client, account types.Account, stakerId uint32, header *coretypes.Header, config types.Configurations, httpClient *client.HttpClient, rogueData types.Rogue, backupNodeActionsToIgnore []string) {
+	_m.Called(_a0, account, stakerId, header, config, httpClient, rogueData, backupNodeActionsToIgnore)
 }
 
 // HandleClaimBounty provides a mock function with given fields: _a0, config, account
@@ -1355,13 +1355,13 @@ func (_m *UtilsCmdInterface) IndexRevealEventsOfCurrentEpoch(_a0 *ethclient.Clie
 	return r0, r1
 }
 
-// InitiateCommit provides a mock function with given fields: _a0, config, account, epoch, stakerId, httpClient, rogueData
-func (_m *UtilsCmdInterface) InitiateCommit(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, stakerId uint32, httpClient *client.HttpClient, rogueData types.Rogue) error {
-	ret := _m.Called(_a0, config, account, epoch, stakerId, httpClient, rogueData)
+// InitiateCommit provides a mock function with given fields: _a0, config, account, epoch, stakerId, latestHeader, httpClient, rogueData
+func (_m *UtilsCmdInterface) InitiateCommit(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, stakerId uint32, latestHeader *coretypes.Header, httpClient *client.HttpClient, rogueData types.Rogue) error {
+	ret := _m.Called(_a0, config, account, epoch, stakerId, latestHeader, httpClient, rogueData)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, uint32, *client.HttpClient, types.Rogue) error); ok {
-		r0 = rf(_a0, config, account, epoch, stakerId, httpClient, rogueData)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, uint32, *coretypes.Header, *client.HttpClient, types.Rogue) error); ok {
+		r0 = rf(_a0, config, account, epoch, stakerId, latestHeader, httpClient, rogueData)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1369,13 +1369,13 @@ func (_m *UtilsCmdInterface) InitiateCommit(_a0 *ethclient.Client, config types.
 	return r0
 }
 
-// InitiatePropose provides a mock function with given fields: _a0, config, account, epoch, staker, blockNumber, rogueData
-func (_m *UtilsCmdInterface) InitiatePropose(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, blockNumber *big.Int, rogueData types.Rogue) error {
-	ret := _m.Called(_a0, config, account, epoch, staker, blockNumber, rogueData)
+// InitiatePropose provides a mock function with given fields: _a0, config, account, epoch, staker, latestHeader, rogueData
+func (_m *UtilsCmdInterface) InitiatePropose(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, latestHeader *coretypes.Header, rogueData types.Rogue) error {
+	ret := _m.Called(_a0, config, account, epoch, staker, latestHeader, rogueData)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, bindings.StructsStaker, *big.Int, types.Rogue) error); ok {
-		r0 = rf(_a0, config, account, epoch, staker, blockNumber, rogueData)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, bindings.StructsStaker, *coretypes.Header, types.Rogue) error); ok {
+		r0 = rf(_a0, config, account, epoch, staker, latestHeader, rogueData)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1383,13 +1383,13 @@ func (_m *UtilsCmdInterface) InitiatePropose(_a0 *ethclient.Client, config types
 	return r0
 }
 
-// InitiateReveal provides a mock function with given fields: _a0, config, account, epoch, staker, rogueData
-func (_m *UtilsCmdInterface) InitiateReveal(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, rogueData types.Rogue) error {
-	ret := _m.Called(_a0, config, account, epoch, staker, rogueData)
+// InitiateReveal provides a mock function with given fields: _a0, config, account, epoch, staker, latestHeader, rogueData
+func (_m *UtilsCmdInterface) InitiateReveal(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, staker bindings.StructsStaker, latestHeader *coretypes.Header, rogueData types.Rogue) error {
+	ret := _m.Called(_a0, config, account, epoch, staker, latestHeader, rogueData)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, bindings.StructsStaker, types.Rogue) error); ok {
-		r0 = rf(_a0, config, account, epoch, staker, rogueData)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, bindings.StructsStaker, *coretypes.Header, types.Rogue) error); ok {
+		r0 = rf(_a0, config, account, epoch, staker, latestHeader, rogueData)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1533,13 +1533,13 @@ func (_m *UtilsCmdInterface) ModifyCollectionStatus(_a0 *ethclient.Client, confi
 	return r0, r1
 }
 
-// Propose provides a mock function with given fields: _a0, config, account, staker, epoch, blockNumber, rogueData
-func (_m *UtilsCmdInterface) Propose(_a0 *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error {
-	ret := _m.Called(_a0, config, account, staker, epoch, blockNumber, rogueData)
+// Propose provides a mock function with given fields: _a0, config, account, staker, epoch, latestHeader, rogueData
+func (_m *UtilsCmdInterface) Propose(_a0 *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, latestHeader *coretypes.Header, rogueData types.Rogue) error {
+	ret := _m.Called(_a0, config, account, staker, epoch, latestHeader, rogueData)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, bindings.StructsStaker, uint32, *big.Int, types.Rogue) error); ok {
-		r0 = rf(_a0, config, account, staker, epoch, blockNumber, rogueData)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, bindings.StructsStaker, uint32, *coretypes.Header, types.Rogue) error); ok {
+		r0 = rf(_a0, config, account, staker, epoch, latestHeader, rogueData)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -1578,25 +1578,25 @@ func (_m *UtilsCmdInterface) ResetUnstakeLock(_a0 *ethclient.Client, config type
 	return r0, r1
 }
 
-// Reveal provides a mock function with given fields: _a0, config, account, epoch, commitData, signature
-func (_m *UtilsCmdInterface) Reveal(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, commitData types.CommitData, signature []byte) (common.Hash, error) {
-	ret := _m.Called(_a0, config, account, epoch, commitData, signature)
+// Reveal provides a mock function with given fields: _a0, config, account, epoch, latestHeader, commitData, signature
+func (_m *UtilsCmdInterface) Reveal(_a0 *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, latestHeader *coretypes.Header, commitData types.CommitData, signature []byte) (common.Hash, error) {
+	ret := _m.Called(_a0, config, account, epoch, latestHeader, commitData, signature)
 
 	var r0 common.Hash
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, types.CommitData, []byte) (common.Hash, error)); ok {
-		return rf(_a0, config, account, epoch, commitData, signature)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, *coretypes.Header, types.CommitData, []byte) (common.Hash, error)); ok {
+		return rf(_a0, config, account, epoch, latestHeader, commitData, signature)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, types.CommitData, []byte) common.Hash); ok {
-		r0 = rf(_a0, config, account, epoch, commitData, signature)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations, types.Account, uint32, *coretypes.Header, types.CommitData, []byte) common.Hash); ok {
+		r0 = rf(_a0, config, account, epoch, latestHeader, commitData, signature)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Hash)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, types.Configurations, types.Account, uint32, types.CommitData, []byte) error); ok {
-		r1 = rf(_a0, config, account, epoch, commitData, signature)
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, types.Configurations, types.Account, uint32, *coretypes.Header, types.CommitData, []byte) error); ok {
+		r1 = rf(_a0, config, account, epoch, latestHeader, commitData, signature)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"encoding/hex"
 	"errors"
+	Types "github.com/ethereum/go-ethereum/core/types"
 	"math"
 	"math/big"
 	"razor/core"
@@ -29,8 +30,8 @@ var globalProposedDataStruct types.ProposeFileData
 // Find iteration using salt as seed
 
 //This functions handles the propose state
-func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) error {
-	if state, err := razorUtils.GetBufferedState(client, config.BufferPercent); err != nil || state != 2 {
+func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configurations, account types.Account, staker bindings.StructsStaker, epoch uint32, latestHeader *Types.Header, rogueData types.Rogue) error {
+	if state, err := razorUtils.GetBufferedState(client, latestHeader, config.BufferPercent); err != nil || state != 2 {
 		log.Error("Not propose state")
 		return err
 	}
@@ -132,8 +133,8 @@ func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configuration
 		}
 		log.Info("Current iteration is less than iteration of last proposed block, can propose")
 	}
-	log.Debugf("Propose: Calling MakeBlock() with arguments blockNumber = %s, epoch = %d, rogueData = %+v", blockNumber, epoch, rogueData)
-	medians, ids, revealedDataMaps, err := cmdUtils.MakeBlock(client, blockNumber, epoch, rogueData)
+	log.Debugf("Propose: Calling MakeBlock() with arguments blockNumber = %s, epoch = %d, rogueData = %+v", latestHeader.Number, epoch, rogueData)
+	medians, ids, revealedDataMaps, err := cmdUtils.MakeBlock(client, latestHeader.Number, epoch, rogueData)
 	if err != nil {
 		log.Error(err)
 		return err

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -20,18 +20,20 @@ import (
 func TestPropose(t *testing.T) {
 
 	var (
-		client      *ethclient.Client
-		account     types.Account
-		config      types.Configurations
-		staker      bindings.StructsStaker
-		epoch       uint32
-		blockNumber *big.Int
+		client  *ethclient.Client
+		account types.Account
+		config  types.Configurations
+		staker  bindings.StructsStaker
+		epoch   uint32
 	)
 
 	salt := []byte{142, 170, 157, 83, 109, 43, 34, 152, 21, 154, 159, 12, 195, 119, 50, 186, 218, 57, 39, 173, 228, 135, 20, 100, 149, 27, 169, 158, 34, 113, 66, 64}
 	saltBytes32 := [32]byte{}
 	copy(saltBytes32[:], salt)
 
+	latestHeader := &Types.Header{
+		Number: big.NewInt(1001),
+	}
 	type args struct {
 		rogueData                  types.Rogue
 		state                      int64
@@ -514,7 +516,7 @@ func TestPropose(t *testing.T) {
 	for _, tt := range tests {
 		SetUpMockInterfaces()
 
-		utilsMock.On("GetBufferedState", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("int32")).Return(tt.args.state, tt.args.stateErr)
+		utilsMock.On("GetBufferedState", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.state, tt.args.stateErr)
 		utilsMock.On("GetNumberOfStakers", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(tt.args.numStakers, tt.args.numStakerErr)
 		cmdUtilsMock.On("GetBiggestStakeAndId", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string"), mock.AnythingOfType("uint32")).Return(tt.args.biggestStake, tt.args.biggestStakerId, tt.args.biggestStakerIdErr)
 		cmdUtilsMock.On("GetSmallestStakeAndId", mock.Anything, mock.Anything).Return(tt.args.smallestStake, tt.args.smallestStakerId, tt.args.smallestStakerIdErr)
@@ -539,7 +541,7 @@ func TestPropose(t *testing.T) {
 
 		utils := &UtilsStruct{}
 		t.Run(tt.name, func(t *testing.T) {
-			err := utils.Propose(client, config, account, staker, epoch, blockNumber, tt.args.rogueData)
+			err := utils.Propose(client, config, account, staker, epoch, latestHeader, tt.args.rogueData)
 			if err == nil || tt.wantErr == nil {
 				if err != tt.wantErr {
 					t.Errorf("Error for Propose function, got = %v, want %v", err, tt.wantErr)

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -31,8 +31,8 @@ func (*UtilsStruct) CheckForLastCommitted(client *ethclient.Client, staker bindi
 }
 
 //This function checks if the state is reveal or not and then reveals the votes
-func (*UtilsStruct) Reveal(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, commitData types.CommitData, signature []byte) (common.Hash, error) {
-	if state, err := razorUtils.GetBufferedState(client, config.BufferPercent); err != nil || state != 1 {
+func (*UtilsStruct) Reveal(client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, latestHeader *Types.Header, commitData types.CommitData, signature []byte) (common.Hash, error) {
+	if state, err := razorUtils.GetBufferedState(client, latestHeader, config.BufferPercent); err != nil || state != 1 {
 		log.Error("Not reveal state")
 		return core.NilHash, err
 	}

--- a/cmd/reveal_test.go
+++ b/cmd/reveal_test.go
@@ -85,12 +85,15 @@ func TestCheckForLastCommitted(t *testing.T) {
 }
 
 func TestReveal(t *testing.T) {
-	var client *ethclient.Client
-	var commitData types.CommitData
-	var signature []byte
-	var account types.Account
-	var config types.Configurations
-	var epoch uint32
+	var (
+		client       *ethclient.Client
+		commitData   types.CommitData
+		signature    []byte
+		account      types.Account
+		config       types.Configurations
+		epoch        uint32
+		latestHeader *Types.Header
+	)
 
 	type args struct {
 		state          int64
@@ -157,7 +160,7 @@ func TestReveal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetBufferedState", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("int32")).Return(tt.args.state, tt.args.stateErr)
+			utilsMock.On("GetBufferedState", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.state, tt.args.stateErr)
 			merkleUtilsMock.On("CreateMerkle", mock.Anything).Return(tt.args.merkleTree, tt.args.merkleTreeErr)
 			cmdUtilsMock.On("GenerateTreeRevealData", mock.Anything, mock.Anything).Return(tt.args.treeRevealData)
 			utilsMock.On("GetTxnOpts", mock.AnythingOfType("types.TransactionOptions")).Return(TxnOpts)
@@ -166,7 +169,7 @@ func TestReveal(t *testing.T) {
 
 			utils := &UtilsStruct{}
 
-			got, err := utils.Reveal(client, config, account, epoch, commitData, signature)
+			got, err := utils.Reveal(client, config, account, epoch, latestHeader, commitData, signature)
 			if got != tt.want {
 				t.Errorf("Txn hash for Reveal function, got = %v, want = %v", got, tt.want)
 			}

--- a/cmd/vote_test.go
+++ b/cmd/vote_test.go
@@ -1216,7 +1216,7 @@ func TestHandleBlock(t *testing.T) {
 			clientUtilsMock.On("BalanceAtWithRetry", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.ethBalance, tt.args.ethBalanceErr)
 			utilsMock.On("GetStakerSRZRBalance", mock.Anything, mock.Anything).Return(tt.args.sRZRBalance, tt.args.sRZRBalanceErr)
 			osMock.On("Exit", mock.AnythingOfType("int")).Return()
-			cmdUtilsMock.On("InitiateCommit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateCommitErr)
+			cmdUtilsMock.On("InitiateCommit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateCommitErr)
 			cmdUtilsMock.On("InitiateReveal", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateRevealErr)
 			cmdUtilsMock.On("InitiatePropose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateProposeErr)
 			cmdUtilsMock.On("HandleDispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.handleDisputeErr)
@@ -1240,6 +1240,7 @@ func TestVote(t *testing.T) {
 		rogueData                 types.Rogue
 		account                   types.Account
 		stakerId                  uint32
+		httpClient                *clientPkg.HttpClient
 		backupNodeActionsToIgnore []string
 	)
 	type args struct {
@@ -1274,7 +1275,7 @@ func TestVote(t *testing.T) {
 			errChan := make(chan error)
 			// Run Vote function in a goroutine
 			go func() {
-				errChan <- ut.Vote(ctx, config, client, rogueData, account, stakerId, backupNodeActionsToIgnore)
+				errChan <- ut.Vote(ctx, config, client, account, stakerId, httpClient, rogueData, backupNodeActionsToIgnore)
 			}()
 
 			// Wait for some time to allow Vote function to execute

--- a/cmd/vote_test.go
+++ b/cmd/vote_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/hex"
 	"errors"
-	Types "github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"os"
 	"path"
@@ -15,6 +14,8 @@ import (
 	"razor/utils"
 	"reflect"
 	"testing"
+
+	Types "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -539,7 +540,7 @@ func TestInitiateCommit(t *testing.T) {
 			cmdUtilsMock.On("GetSalt", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.salt, tt.args.saltErr)
 			cmdUtilsMock.On("HandleCommitState", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.commitData, tt.args.commitDataErr)
 			pathMock.On("GetDefaultPath").Return(tt.args.path, tt.args.pathErr)
-			cmdUtilsMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.commitTxn, tt.args.commitTxnErr)
+			cmdUtilsMock.On("Commit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.commitTxn, tt.args.commitTxnErr)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(tt.args.waitForBlockCompletionErr)
 			pathMock.On("GetCommitDataFileName", mock.AnythingOfType("string")).Return(tt.args.fileName, tt.args.fileNameErr)
 			fileUtilsMock.On("SaveDataToCommitJsonFile", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.saveErr)
@@ -762,7 +763,7 @@ func TestInitiateReveal(t *testing.T) {
 			cmdUtilsMock.On("CalculateSecret", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.signature, tt.args.secret, tt.args.secretErr)
 			cmdUtilsMock.On("GetSalt", mock.Anything, mock.Anything).Return([32]byte{}, nil)
 			utilsMock.On("GetCommitment", mock.Anything, mock.Anything).Return(types.Commitment{}, nil)
-			cmdUtilsMock.On("Reveal", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.revealTxn, tt.args.revealTxnErr)
+			cmdUtilsMock.On("Reveal", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.revealTxn, tt.args.revealTxnErr)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(nil)
 			ut := &UtilsStruct{}
 			if err := ut.InitiateReveal(client, config, account, tt.args.epoch, tt.args.staker, latestHeader, tt.args.rogueData); (err != nil) != tt.wantErr {
@@ -881,7 +882,7 @@ func TestInitiatePropose(t *testing.T) {
 			utilsMock.On("GetMinStakeAmount", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.minStakeAmount, tt.args.minStakeAmountErr)
 			utilsMock.On("GetEpochLastProposed", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("uint32")).Return(tt.args.lastProposal, tt.args.lastProposalErr)
 			utilsMock.On("GetEpochLastRevealed", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("uint32")).Return(tt.args.lastReveal, tt.args.lastRevealErr)
-			cmdUtilsMock.On("Propose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.proposeTxnErr)
+			cmdUtilsMock.On("Propose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.proposeTxnErr)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(nil)
 			ut := &UtilsStruct{}
 			if err := ut.InitiatePropose(client, config, account, tt.args.epoch, tt.args.staker, latestHeader, rogueData); (err != nil) != tt.wantErr {
@@ -901,7 +902,7 @@ func TestHandleBlock(t *testing.T) {
 	)
 
 	latestHeader := &Types.Header{
-		Number: big.NewInt(1),
+		Number: big.NewInt(1001),
 	}
 	type args struct {
 		config               types.Configurations
@@ -1207,15 +1208,15 @@ func TestHandleBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetBufferedState", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("int32")).Return(tt.args.state, tt.args.stateErr)
+			utilsMock.On("GetBufferedState", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.state, tt.args.stateErr)
 			utilsMock.On("GetEpoch", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.epoch, tt.args.epochErr)
 			utilsMock.On("GetStaker", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("uint32")).Return(tt.args.staker, tt.args.stakerErr)
 			clientUtilsMock.On("BalanceAtWithRetry", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.ethBalance, tt.args.ethBalanceErr)
 			utilsMock.On("GetStakerSRZRBalance", mock.Anything, mock.Anything).Return(tt.args.sRZRBalance, tt.args.sRZRBalanceErr)
 			osMock.On("Exit", mock.AnythingOfType("int")).Return()
 			cmdUtilsMock.On("InitiateCommit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateCommitErr)
-			cmdUtilsMock.On("InitiateReveal", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateRevealErr)
-			cmdUtilsMock.On("InitiatePropose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateProposeErr)
+			cmdUtilsMock.On("InitiateReveal", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateRevealErr)
+			cmdUtilsMock.On("InitiatePropose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.initiateProposeErr)
 			cmdUtilsMock.On("HandleDispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.handleDisputeErr)
 			utilsMock.On("IsFlagPassed", mock.AnythingOfType("string")).Return(tt.args.isFlagPassed)
 			cmdUtilsMock.On("HandleClaimBounty", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.handleClaimBountyErr)

--- a/utils/common.go
+++ b/utils/common.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"errors"
+	Types "github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -52,21 +53,17 @@ func (*UtilsStruct) FetchBalance(client *ethclient.Client, accountAddress string
 	return balance, nil
 }
 
-func (*UtilsStruct) GetBufferedState(client *ethclient.Client, buffer int32) (int64, error) {
-	block, err := ClientInterface.GetLatestBlockWithRetry(client)
-	if err != nil {
-		return -1, err
-	}
+func (*UtilsStruct) GetBufferedState(client *ethclient.Client, header *Types.Header, buffer int32) (int64, error) {
 	stateBuffer, err := UtilsInterface.GetStateBuffer(client)
 	if err != nil {
 		return -1, err
 	}
 	lowerLimit := (core.StateLength * uint64(buffer)) / 100
 	upperLimit := core.StateLength - (core.StateLength*uint64(buffer))/100
-	if block.Time%(core.StateLength) > upperLimit-stateBuffer || block.Time%(core.StateLength) < lowerLimit+stateBuffer {
+	if header.Time%(core.StateLength) > upperLimit-stateBuffer || header.Time%(core.StateLength) < lowerLimit+stateBuffer {
 		return -1, nil
 	}
-	state := block.Time / core.StateLength
+	state := header.Time / core.StateLength
 	return int64(state % core.NumberOfStates), nil
 }
 

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -366,7 +366,6 @@ func TestGetBufferedState(t *testing.T) {
 
 	type args struct {
 		block          *types.Header
-		blockErr       error
 		buffer         int32
 		stateBuffer    uint64
 		stateBufferErr error
@@ -391,18 +390,7 @@ func TestGetBufferedState(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Test 2: When there is an error in getting block",
-			args: args{
-				block: &types.Header{
-					Number: big.NewInt(100),
-				},
-				blockErr: errors.New("block error"),
-			},
-			want:    -1,
-			wantErr: true,
-		},
-		{
-			name: "Test 3: When blockNumber%(core.StateLength) is greater than lowerLimit",
+			name: "Test 2: When blockNumber%(core.StateLength) is greater than lowerLimit",
 			args: args{
 				block: &types.Header{
 					Time: 1080,
@@ -414,7 +402,7 @@ func TestGetBufferedState(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Test 4: When GetBufferedState() executes successfully and state we get is other than 0",
+			name: "Test 3: When GetBufferedState() executes successfully and state we get is other than 0",
 			args: args{
 				block: &types.Header{
 					Time: 900,
@@ -427,7 +415,7 @@ func TestGetBufferedState(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Test 5: When there is an error in getting stateBuffer",
+			name: "Test 4: When there is an error in getting stateBuffer",
 			args: args{
 				block: &types.Header{
 					Time: 100,
@@ -454,9 +442,8 @@ func TestGetBufferedState(t *testing.T) {
 			utils := StartRazor(optionsPackageStruct)
 
 			utilsMock.On("GetStateBuffer", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.stateBuffer, tt.args.stateBufferErr)
-			clientUtilsMock.On("GetLatestBlockWithRetry", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.block, tt.args.blockErr)
 
-			got, err := utils.GetBufferedState(client, tt.args.buffer)
+			got, err := utils.GetBufferedState(client, tt.args.block, tt.args.buffer)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetBufferedState() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -126,7 +126,7 @@ type Utils interface {
 	HandleOfficialJobsFromJSONFile(client *ethclient.Client, collection bindings.StructsCollection, dataString string) ([]bindings.StructsJob, []uint16)
 	ConnectToClient(provider string) *ethclient.Client
 	FetchBalance(client *ethclient.Client, accountAddress string) (*big.Int, error)
-	GetBufferedState(client *ethclient.Client, buffer int32) (int64, error)
+	GetBufferedState(client *ethclient.Client, header *Types.Header, buffer int32) (int64, error)
 	WaitForBlockCompletion(client *ethclient.Client, hashToRead string) error
 	CheckEthBalanceIsZero(client *ethclient.Client, address string)
 	AssignStakerId(flagSet *pflag.FlagSet, client *ethclient.Client, address string) (uint32, error)

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -14,6 +14,8 @@ import (
 
 	common "github.com/ethereum/go-ethereum/common"
 
+	coretypes "github.com/ethereum/go-ethereum/core/types"
+
 	ethclient "github.com/ethereum/go-ethereum/ethclient"
 
 	mock "github.com/stretchr/testify/mock"
@@ -570,23 +572,23 @@ func (_m *Utils) GetBlockManagerWithOpts(_a0 *ethclient.Client) (*bindings.Block
 	return r0, r1
 }
 
-// GetBufferedState provides a mock function with given fields: _a0, buffer
-func (_m *Utils) GetBufferedState(_a0 *ethclient.Client, buffer int32) (int64, error) {
-	ret := _m.Called(_a0, buffer)
+// GetBufferedState provides a mock function with given fields: _a0, header, buffer
+func (_m *Utils) GetBufferedState(_a0 *ethclient.Client, header *coretypes.Header, buffer int32) (int64, error) {
+	ret := _m.Called(_a0, header, buffer)
 
 	var r0 int64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, int32) (int64, error)); ok {
-		return rf(_a0, buffer)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, *coretypes.Header, int32) (int64, error)); ok {
+		return rf(_a0, header, buffer)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, int32) int64); ok {
-		r0 = rf(_a0, buffer)
+	if rf, ok := ret.Get(0).(func(*ethclient.Client, *coretypes.Header, int32) int64); ok {
+		r0 = rf(_a0, header, buffer)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, int32) error); ok {
-		r1 = rf(_a0, buffer)
+	if rf, ok := ret.Get(1).(func(*ethclient.Client, *coretypes.Header, int32) error); ok {
+		r1 = rf(_a0, header, buffer)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
# Description

Reduced number of RPC calls like `GetBlockNumber` and `GetStakerId` which were redundantly called in few functions.

- Removed `GetLatestBlockWithRetry()` calls in functions like `GetBufferedState` and `GetEpoch`and used the existing header provided from the parent `HandleBlock()` function.

- Called `GetStakerId` once and passed the stakerId as a dependency to all the dependent functions as the value of staker Id once received would never change.
 
Fixes # https://github.com/razor-network/oracle-node/issues/1199
