### PR TITLE
fix: updated default config values to support both 20 min and shorter 5 min epoch 

### DIFF
--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -209,7 +209,7 @@ func (*UtilsStruct) GetMultiplier() (float32, error) {
 func (*UtilsStruct) GetBufferPercent() (int32, error) {
 	const (
 		MinBufferPercent = 0
-		MaxBufferPercent = 5
+		MaxBufferPercent = 30
 	)
 
 	bufferPercent, err := getConfigValue("buffer", "int32", core.DefaultBufferPercent, "buffer")
@@ -237,8 +237,8 @@ func (*UtilsStruct) GetBufferPercent() (int32, error) {
 //This function returns the wait time
 func (*UtilsStruct) GetWaitTime() (int32, error) {
 	const (
-		MinWaitTime = 1 // Minimum wait time in seconds
-		MaxWaitTime = 5 // Maximum wait time in seconds
+		MinWaitTime = 1  // Minimum wait time in seconds
+		MaxWaitTime = 30 // Maximum wait time in seconds
 	)
 
 	waitTime, err := getConfigValue("wait", "int32", core.DefaultWaitTime, "wait")
@@ -334,7 +334,7 @@ func (*UtilsStruct) GetGasLimitOverride() (uint64, error) {
 func (*UtilsStruct) GetRPCTimeout() (int64, error) {
 	const (
 		MinRPCTimeout = 10 // Minimum RPC timeout in seconds
-		MaxRPCTimeout = 20 // Maximum RPC timeout in seconds
+		MaxRPCTimeout = 60 // Maximum RPC timeout in seconds
 	)
 
 	rpcTimeout, err := getConfigValue("rpcTimeout", "int64", core.DefaultRPCTimeout, "rpcTimeout")
@@ -356,7 +356,7 @@ func (*UtilsStruct) GetRPCTimeout() (int64, error) {
 func (*UtilsStruct) GetHTTPTimeout() (int64, error) {
 	const (
 		MinHTTPTimeout = 10 // Minimum HTTP timeout in seconds
-		MaxHTTPTimeout = 20 // Maximum HTTP timeout in seconds
+		MaxHTTPTimeout = 60 // Maximum HTTP timeout in seconds
 	)
 
 	httpTimeout, err := getConfigValue("httpTimeout", "int64", core.DefaultHTTPTimeout, "httpTimeout")

--- a/config.sh
+++ b/config.sh
@@ -19,15 +19,15 @@ then
   GAS_MULTIPLIER=1.0
 fi
 
-read -rp "Buffer Percent: (0) " BUFFER
+read -rp "Buffer Percent: (20) " BUFFER
 if [ -z "$BUFFER" ];
 then
-  BUFFER=0
+  BUFFER=20
 fi
 
-read -rp "Wait Time: (1) " WAIT_TIME
+read -rp "Wait Time: (5) " WAIT_TIME
 if [ -z "$WAIT_TIME" ]; then
-   WAIT_TIME=1
+   WAIT_TIME=5
 fi
 
 read -rp "Gas Price: (0) " GAS_PRICE

--- a/core/constants.go
+++ b/core/constants.go
@@ -26,9 +26,9 @@ const BlockCompletionTimeout = 30
 //Following are the default config values for all the config parameters
 const (
 	DefaultGasMultiplier    float32 = 1.0
-	DefaultBufferPercent    int32   = 0
+	DefaultBufferPercent    int32   = 20
 	DefaultGasPrice         int32   = 0
-	DefaultWaitTime         int32   = 1
+	DefaultWaitTime         int32   = 5
 	DefaultGasLimit         float32 = 2
 	DefaultGasLimitOverride uint64  = 30000000
 	DefaultRPCTimeout       int64   = 10


### PR DESCRIPTION
# Description

Updated the default, maximum and minimum config values in core/constants.go and cmd/config-utils.go` in order to support 20 min epoch which in place by default also supports shorter epoch of 5 min.

Fixes https://github.com/razor-network/oracle-node/issues/1208

