### PR TITLE
revert: median concurrency changes

### DIFF
--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -391,90 +391,43 @@ func (*UtilsStruct) GetSortedRevealedValues(client *ethclient.Client, blockNumbe
 		return nil, err
 	}
 	log.Debugf("GetSortedRevealedValues: Revealed Data: %+v", assignedAsset)
-
-	var wg sync.WaitGroup
-	resultsChan := make(chan *types.AssetResult, len(assignedAsset))
-
-	for _, asset := range assignedAsset {
-		wg.Add(1)
-		go processAsset(asset, resultsChan, &wg)
-	}
-
-	wg.Wait()
-	close(resultsChan)
-
 	revealedValuesWithIndex := make(map[uint16][]*big.Int)
 	voteWeights := make(map[string]*big.Int)
 	influenceSum := make(map[uint16]*big.Int)
+	log.Debug("Calculating sorted revealed values, vote weights and influence sum...")
+	for _, asset := range assignedAsset {
+		for _, assetValue := range asset.RevealedValues {
+			if revealedValuesWithIndex[assetValue.LeafId] == nil {
+				revealedValuesWithIndex[assetValue.LeafId] = []*big.Int{assetValue.Value}
+			} else {
+				if !utils.ContainsBigInteger(revealedValuesWithIndex[assetValue.LeafId], assetValue.Value) {
+					revealedValuesWithIndex[assetValue.LeafId] = append(revealedValuesWithIndex[assetValue.LeafId], assetValue.Value)
+				}
+			}
+			//Calculate vote weights
+			if voteWeights[assetValue.Value.String()] == nil {
+				voteWeights[assetValue.Value.String()] = big.NewInt(0)
+			}
+			voteWeights[assetValue.Value.String()] = big.NewInt(0).Add(voteWeights[assetValue.Value.String()], asset.Influence)
 
-	for result := range resultsChan {
-		for leafId, values := range result.RevealedValuesWithIndex {
-			revealedValuesWithIndex[leafId] = append(revealedValuesWithIndex[leafId], values...)
-		}
-		for value, weight := range result.VoteWeights {
-			if voteWeights[value] == nil {
-				voteWeights[value] = weight
-			} else {
-				voteWeights[value].Add(voteWeights[value], weight)
+			//Calculate influence sum
+			if influenceSum[assetValue.LeafId] == nil {
+				influenceSum[assetValue.LeafId] = big.NewInt(0)
 			}
-		}
-		for leafId, sum := range result.InfluenceSum {
-			if influenceSum[leafId] == nil {
-				influenceSum[leafId] = sum
-			} else {
-				influenceSum[leafId].Add(influenceSum[leafId], sum)
-			}
+			influenceSum[assetValue.LeafId] = big.NewInt(0).Add(influenceSum[assetValue.LeafId], asset.Influence)
 		}
 	}
-
-	for _, values := range revealedValuesWithIndex {
-		sort.Slice(values, func(i, j int) bool {
-			return values[i].Cmp(values[j]) == -1
+	//sort revealed values
+	for _, element := range revealedValuesWithIndex {
+		sort.Slice(element, func(i, j int) bool {
+			return element[i].Cmp(element[j]) == -1
 		})
 	}
-
 	return &types.RevealedDataMaps{
 		SortedRevealedValues: revealedValuesWithIndex,
 		VoteWeights:          voteWeights,
 		InfluenceSum:         influenceSum,
 	}, nil
-}
-
-func processAsset(asset types.RevealedStruct, resultsChan chan<- *types.AssetResult, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	revealedValuesWithIndex := make(map[uint16][]*big.Int)
-	voteWeights := make(map[string]*big.Int)
-	influenceSum := make(map[uint16]*big.Int)
-
-	for _, assetValue := range asset.RevealedValues {
-		leafId := assetValue.LeafId
-		valueStr := assetValue.Value.String()
-		influence := asset.Influence
-
-		// Append the leaf value to the revealed values slice if it's not already present
-		if !utils.ContainsBigInteger(revealedValuesWithIndex[leafId], assetValue.Value) {
-			revealedValuesWithIndex[leafId] = append(revealedValuesWithIndex[leafId], assetValue.Value)
-		}
-
-		// Calculate vote weights
-		if voteWeights[valueStr] == nil {
-			voteWeights[valueStr] = big.NewInt(0)
-		}
-		voteWeights[valueStr] = voteWeights[valueStr].Add(voteWeights[valueStr], influence)
-
-		// Calculate influence sum
-		if influenceSum[leafId] == nil {
-			influenceSum[leafId] = big.NewInt(0)
-		}
-		influenceSum[leafId] = influenceSum[leafId].Add(influenceSum[leafId], influence)
-	}
-
-	resultsChan <- &types.AssetResult{
-		RevealedValuesWithIndex: revealedValuesWithIndex,
-		VoteWeights:             voteWeights,
-		InfluenceSum:            influenceSum,
-	}
 }
 
 //This function returns the medians, idsRevealedInThisEpoch and revealedDataMaps

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -227,7 +227,7 @@ func (*UtilsStruct) GetBiggestStakeAndId(client *ethclient.Client, address strin
 		biggestStakerId uint32
 		mu              sync.Mutex
 		wg              sync.WaitGroup
-		errChan         = make(chan error, numberOfStakers)
+		errChan         = make(chan error, 1)
 	)
 
 	log.Debug("Iterating over all the stakers...")

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -208,6 +208,8 @@ func (*UtilsStruct) GetBiggestStakeAndId(client *ethclient.Client, address strin
 	if numberOfStakers == 0 {
 		return nil, 0, errors.New("numberOfStakers is 0")
 	}
+	var biggestStakerId uint32
+	biggestStake := big.NewInt(0)
 
 	bufferPercent, err := cmdUtils.GetBufferPercent()
 	if err != nil {
@@ -222,53 +224,30 @@ func (*UtilsStruct) GetBiggestStakeAndId(client *ethclient.Client, address strin
 	log.Debug("GetBiggestStakeAndId: State remaining time: ", stateRemainingTime)
 	stateTimeout := time.NewTimer(time.Second * time.Duration(stateRemainingTime))
 
-	var (
-		biggestStake    = big.NewInt(0)
-		biggestStakerId uint32
-		mu              sync.Mutex
-		wg              sync.WaitGroup
-		errChan         = make(chan error, 1)
-	)
-
 	log.Debug("Iterating over all the stakers...")
+loop:
 	for i := 1; i <= int(numberOfStakers); i++ {
-		wg.Add(1)
-		go func(stakerId int) {
-			defer wg.Done()
-
-			select {
-			case <-stateTimeout.C:
-				errChan <- errors.New("state timeout error")
-				return
-			default:
-				stake, err := razorUtils.GetStakeSnapshot(client, uint32(stakerId), epoch)
-				if err != nil {
-					errChan <- err
-					return
-				}
-
-				mu.Lock()
-				defer mu.Unlock()
-				if stake.Cmp(biggestStake) > 0 {
-					biggestStake = stake
-					biggestStakerId = uint32(stakerId)
-				}
+		select {
+		case <-stateTimeout.C:
+			log.Error("State timeout!")
+			err = errors.New("state timeout error")
+			break loop
+		default:
+			log.Debug("Propose: Staker Id: ", i)
+			stake, err := razorUtils.GetStakeSnapshot(client, uint32(i), epoch)
+			if err != nil {
+				return nil, 0, err
 			}
-		}(i)
+			log.Debugf("Stake Snapshot of staker having stakerId %d is %s", i, stake)
+			if stake.Cmp(biggestStake) > 0 {
+				biggestStake = stake
+				biggestStakerId = uint32(i)
+			}
+		}
 	}
-
-	wg.Wait()
-
-	select {
-	case err := <-errChan:
-		return nil, 0, err
-	default:
-	}
-
 	if err != nil {
 		return nil, 0, err
 	}
-
 	log.Debug("Propose: BiggestStake: ", biggestStake)
 	log.Debug("Propose: Biggest Staker Id: ", biggestStakerId)
 	return biggestStake, biggestStakerId, nil

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -492,42 +492,31 @@ func (*UtilsStruct) MakeBlock(client *ethclient.Client, blockNumber *big.Int, ep
 	}
 	log.Debug("MakeBlock: Active collections: ", activeCollections)
 
-	resultsChan := make(chan types.MedianResult, len(activeCollections))
-	var wg sync.WaitGroup
+	var (
+		medians                []*big.Int
+		idsRevealedInThisEpoch []uint16
+	)
 
 	log.Debug("Iterating over all the active collections for medians calculation....")
 	for leafId := uint16(0); leafId < uint16(len(activeCollections)); leafId++ {
-		wg.Add(1)
-		go func(leafId uint16) {
-			defer wg.Done()
-			median := calculateMedianForLeafId(revealedDataMaps, leafId, rogueData)
-			if median != nil {
-				resultsChan <- types.MedianResult{LeafId: leafId, Median: median}
-			}
-		}(leafId)
-	}
-
-	wg.Wait()
-	close(resultsChan)
-
-	// Storing the median results temporarily in a map
-	medianResults := make(map[uint16]*big.Int)
-	for result := range resultsChan {
-		medianResults[result.LeafId] = result.Median
-	}
-
-	var medians []*big.Int
-	var idsRevealedInThisEpoch []uint16
-
-	// Storing medians in order of increasing leafIds starting from 0
-	for leafId := uint16(0); leafId < uint16(len(activeCollections)); leafId++ {
-		if median, exists := medianResults[leafId]; exists {
-			medians = append(medians, median)
+		influenceSum := revealedDataMaps.InfluenceSum[leafId]
+		if influenceSum != nil && influenceSum.Cmp(big.NewInt(0)) != 0 {
 			idsRevealedInThisEpoch = append(idsRevealedInThisEpoch, activeCollections[leafId])
+			if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "medians") {
+				medians = append(medians, razorUtils.GetRogueRandomValue(10000000))
+				continue
+			}
+			accWeight := big.NewInt(0)
+			for i := 0; i < len(revealedDataMaps.SortedRevealedValues[leafId]); i++ {
+				revealedValue := revealedDataMaps.SortedRevealedValues[leafId][i]
+				accWeight = accWeight.Add(accWeight, revealedDataMaps.VoteWeights[revealedValue.String()])
+				if accWeight.Cmp(influenceSum.Div(influenceSum, big.NewInt(2))) > 0 {
+					medians = append(medians, revealedValue)
+					break
+				}
+			}
 		}
 	}
-
-	// Handling rogue data
 	if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "missingIds") {
 		log.Warn("YOU ARE PROPOSING IDS REVEALED IN ROGUE MODE, THIS CAN INCUR PENALTIES!")
 		//Replacing the last ID: id with id+1 in idsRevealed array if rogueMode == missingIds
@@ -546,28 +535,7 @@ func (*UtilsStruct) MakeBlock(client *ethclient.Client, blockNumber *big.Int, ep
 		idsRevealedInThisEpoch[0] = idsRevealedInThisEpoch[1]
 		idsRevealedInThisEpoch[1] = temp
 	}
-
 	return medians, idsRevealedInThisEpoch, revealedDataMaps, nil
-}
-
-func calculateMedianForLeafId(revealedDataMaps *types.RevealedDataMaps, leafId uint16, rogueData types.Rogue) *big.Int {
-	influenceSum := revealedDataMaps.InfluenceSum[leafId]
-	if influenceSum != nil && influenceSum.Cmp(big.NewInt(0)) != 0 {
-		if rogueData.IsRogue && utils.Contains(rogueData.RogueMode, "medians") {
-			return razorUtils.GetRogueRandomValue(10000000)
-		}
-		accWeight := big.NewInt(0)
-		for _, revealedValue := range revealedDataMaps.SortedRevealedValues[leafId] {
-			accWeight = accWeight.Add(accWeight, revealedDataMaps.VoteWeights[revealedValue.String()])
-			if accWeight.Cmp(influenceSum.Div(influenceSum, big.NewInt(2))) > 0 {
-				log.Debugf("LeafId: %d, Calculated value %v", leafId, revealedValue)
-				return revealedValue
-			}
-		}
-	}
-	// Returning nil if no median is found or if influenceSum is nil or zero
-	log.Debugf("No median found for LeafId %d", leafId)
-	return nil
 }
 
 func (*UtilsStruct) GetSmallestStakeAndId(client *ethclient.Client, epoch uint32) (*big.Int, uint32, error) {

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -1338,25 +1338,27 @@ func BenchmarkMakeBlock(b *testing.B) {
 	)
 
 	table := []struct {
-		numOfVotesPerLeafId int
-		numOfLeafIds        int
+		numOfVotes int
 	}{
-		{numOfVotesPerLeafId: 5, numOfLeafIds: 10},
-		{numOfVotesPerLeafId: 50, numOfLeafIds: 100},
-		{numOfVotesPerLeafId: 100, numOfLeafIds: 500},
-		{numOfVotesPerLeafId: 500, numOfLeafIds: 1000},
-		{numOfVotesPerLeafId: 1000, numOfLeafIds: 10000},
+		{numOfVotes: 1},
+		{numOfVotes: 100},
+		{numOfVotes: 1000},
+		{numOfVotes: 10000},
+		{numOfVotes: 100000},
 	}
 	for _, v := range table {
-		b.Run(fmt.Sprintf("LeafIds_%d_VotesPerLeafId_%d", v.numOfLeafIds, v.numOfVotesPerLeafId), func(b *testing.B) {
+		b.Run(fmt.Sprintf("Number_Of_Votes_%d", v.numOfVotes), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				SetUpMockInterfaces()
 
-				revealedDataMaps := GetDummyRevealedDataMaps(v.numOfLeafIds, v.numOfVotesPerLeafId)
+				votes := GetDummyVotes(v.numOfVotes)
 
-				cmdUtilsMock.On("GetSortedRevealedValues", mock.Anything, mock.Anything, mock.Anything).Return(revealedDataMaps, nil)
-				utilsMock.On("GetActiveCollectionIds", mock.Anything).Return(GetDummyActiveCollections(v.numOfLeafIds), nil)
-
+				cmdUtilsMock.On("GetSortedRevealedValues", mock.Anything, mock.Anything, mock.Anything).Return(&types.RevealedDataMaps{
+					SortedRevealedValues: map[uint16][]*big.Int{0: votes},
+					VoteWeights:          map[string]*big.Int{(big.NewInt(1).Mul(big.NewInt(697718000), big.NewInt(1e18))).String(): big.NewInt(100)},
+					InfluenceSum:         map[uint16]*big.Int{0: big.NewInt(100)},
+				}, nil)
+				utilsMock.On("GetActiveCollectionIds", mock.Anything).Return([]uint16{1}, nil)
 				ut := &UtilsStruct{}
 				_, _, _, err := ut.MakeBlock(client, blockNumber, epoch, types.Rogue{IsRogue: false})
 				if err != nil {
@@ -1373,42 +1375,6 @@ func GetDummyVotes(numOfVotes int) []*big.Int {
 		result = append(result, big.NewInt(1).Mul(big.NewInt(697718000), big.NewInt(1e18)))
 	}
 	return result
-}
-
-func GetDummyActiveCollections(numOfCollections int) []uint16 {
-	var collections []uint16
-	for i := 0; i < numOfCollections; i++ {
-		collections = append(collections, uint16(i+1))
-	}
-	return collections
-}
-
-func GetDummyRevealedDataMaps(numOfLeafIds, numOfVotesPerLeafId int) *types.RevealedDataMaps {
-	sortedRevealedValues := make(map[uint16][]*big.Int)
-	voteWeights := make(map[string]*big.Int)
-	influenceSum := make(map[uint16]*big.Int)
-
-	for leafId := 0; leafId < numOfLeafIds; leafId++ {
-		var votes []*big.Int
-		totalInfluence := big.NewInt(0)
-
-		for voteId := 0; voteId < numOfVotesPerLeafId; voteId++ {
-			voteValue := big.NewInt(1).Mul(big.NewInt(int64(leafId+voteId+1)), big.NewInt(1e18)) // Example vote value
-			votes = append(votes, voteValue)
-			weight := big.NewInt(100) // Example weight
-			voteWeights[voteValue.String()] = weight
-			totalInfluence.Add(totalInfluence, weight)
-		}
-
-		sortedRevealedValues[uint16(leafId)] = votes
-		influenceSum[uint16(leafId)] = totalInfluence
-	}
-
-	return &types.RevealedDataMaps{
-		SortedRevealedValues: sortedRevealedValues,
-		VoteWeights:          voteWeights,
-		InfluenceSum:         influenceSum,
-	}
 }
 
 func GetDummyAssignedAssets(asset types.RevealedStruct, numOfAssignedAssets int) []types.RevealedStruct {

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -1099,17 +1099,145 @@ func TestGetSortedRevealedValues(t *testing.T) {
 		{
 			name: "Test 1: When GetSortedRevealedValues executes successfully",
 			args: args{
-				assignedAssets: []types.RevealedStruct{{RevealedValues: []types.AssignedAsset{{LeafId: 1, Value: big.NewInt(100)}}, Influence: big.NewInt(100)}},
+				assignedAssets: []types.RevealedStruct{
+					{
+						RevealedValues: []types.AssignedAsset{
+							{LeafId: 3, Value: big.NewInt(601)},
+							{LeafId: 6, Value: big.NewInt(750)},
+							{LeafId: 1, Value: big.NewInt(400)},
+						},
+						Influence: big.NewInt(10000000),
+					},
+					{
+						RevealedValues: []types.AssignedAsset{
+							{LeafId: 10, Value: big.NewInt(1100)},
+							{LeafId: 5, Value: big.NewInt(900)},
+							{LeafId: 7, Value: big.NewInt(302)},
+						},
+						Influence: big.NewInt(20000000),
+					},
+					{
+						RevealedValues: []types.AssignedAsset{
+							{LeafId: 3, Value: big.NewInt(600)},
+							{LeafId: 7, Value: big.NewInt(300)},
+							{LeafId: 9, Value: big.NewInt(1600)},
+						},
+						Influence: big.NewInt(30000000),
+					},
+					{
+						RevealedValues: []types.AssignedAsset{
+							{LeafId: 10, Value: big.NewInt(1105)},
+							{LeafId: 8, Value: big.NewInt(950)},
+							{LeafId: 7, Value: big.NewInt(300)},
+						},
+						Influence: big.NewInt(40000000),
+					},
+				},
 			},
 			want: &types.RevealedDataMaps{
-				SortedRevealedValues: map[uint16][]*big.Int{1: {big.NewInt(100)}},
-				VoteWeights:          map[string]*big.Int{big.NewInt(100).String(): big.NewInt(100)},
-				InfluenceSum:         map[uint16]*big.Int{1: big.NewInt(100)},
+				SortedRevealedValues: map[uint16][]*big.Int{
+					1:  {big.NewInt(400)},
+					3:  {big.NewInt(600), big.NewInt(601)},
+					5:  {big.NewInt(900)},
+					6:  {big.NewInt(750)},
+					7:  {big.NewInt(300), big.NewInt(302)},
+					8:  {big.NewInt(950)},
+					9:  {big.NewInt(1600)},
+					10: {big.NewInt(1100), big.NewInt(1105)},
+				},
+				VoteWeights: map[string]*big.Int{
+					"1600": big.NewInt(30000000),
+					"300":  big.NewInt(70000000),
+					"302":  big.NewInt(20000000),
+					"400":  big.NewInt(10000000),
+					"600":  big.NewInt(30000000),
+					"601":  big.NewInt(10000000),
+					"750":  big.NewInt(10000000),
+					"1100": big.NewInt(20000000),
+					"1105": big.NewInt(40000000),
+					"950":  big.NewInt(40000000),
+					"900":  big.NewInt(20000000),
+				},
+				InfluenceSum: map[uint16]*big.Int{
+					1:  big.NewInt(10000000),
+					3:  big.NewInt(40000000),
+					5:  big.NewInt(20000000),
+					6:  big.NewInt(10000000),
+					7:  big.NewInt(90000000),
+					8:  big.NewInt(40000000),
+					9:  big.NewInt(30000000),
+					10: big.NewInt(60000000),
+				},
 			},
 			wantErr: false,
 		},
 		{
-			name: "Test 2: When there is an error in getting assignedAssets",
+			name: "Test 2: When there are multiple equal and unequal vote values for single leafId",
+			args: args{
+				assignedAssets: []types.RevealedStruct{
+					{
+						RevealedValues: []types.AssignedAsset{
+							{LeafId: 1, Value: big.NewInt(600)},
+							{LeafId: 2, Value: big.NewInt(750)},
+							{LeafId: 3, Value: big.NewInt(400)},
+						},
+						Influence: big.NewInt(10000000),
+					},
+					{
+						RevealedValues: []types.AssignedAsset{
+							{LeafId: 1, Value: big.NewInt(601)},
+							{LeafId: 2, Value: big.NewInt(752)},
+						},
+						Influence: big.NewInt(20000000),
+					},
+					{
+						RevealedValues: []types.AssignedAsset{
+							{LeafId: 1, Value: big.NewInt(601)},
+							{LeafId: 2, Value: big.NewInt(756)},
+							{LeafId: 4, Value: big.NewInt(1600)},
+						},
+						Influence: big.NewInt(30000000),
+					},
+				},
+			},
+			want: &types.RevealedDataMaps{
+				SortedRevealedValues: map[uint16][]*big.Int{
+					1: {big.NewInt(600), big.NewInt(601)},
+					2: {big.NewInt(750), big.NewInt(752), big.NewInt(756)},
+					3: {big.NewInt(400)},
+					4: {big.NewInt(1600)},
+				},
+				VoteWeights: map[string]*big.Int{
+					"1600": big.NewInt(30000000),
+					"400":  big.NewInt(10000000),
+					"600":  big.NewInt(10000000),
+					"601":  big.NewInt(50000000),
+					"750":  big.NewInt(10000000),
+					"752":  big.NewInt(20000000),
+					"756":  big.NewInt(30000000),
+				},
+				InfluenceSum: map[uint16]*big.Int{
+					1: big.NewInt(60000000),
+					2: big.NewInt(60000000),
+					3: big.NewInt(10000000),
+					4: big.NewInt(30000000),
+				},
+			},
+		},
+		{
+			name: "Test 3: When assignedAssets is empty",
+			args: args{
+				assignedAssets: []types.RevealedStruct{},
+			},
+			want: &types.RevealedDataMaps{
+				SortedRevealedValues: map[uint16][]*big.Int{},
+				VoteWeights:          map[string]*big.Int{},
+				InfluenceSum:         map[uint16]*big.Int{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test 4: When there is an error in getting assignedAssets",
 			args: args{
 				assignedAssetsErr: errors.New("error in getting assets"),
 			},

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -578,7 +578,7 @@ func TestGetBiggestStakeAndId(t *testing.T) {
 		{
 			name: "Test 1: When GetBiggestStakeAndId function executes successfully",
 			args: args{
-				numOfStakers:  1,
+				numOfStakers:  2,
 				remainingTime: 10,
 				stake:         big.NewInt(1).Mul(big.NewInt(5326), big.NewInt(1e18)),
 			},

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -9,11 +9,9 @@ import (
 	"razor/pkg/bindings"
 	"razor/utils"
 	"strings"
-	"sync"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	Types "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
@@ -137,25 +135,14 @@ func (*UtilsStruct) IndexRevealEventsOfCurrentEpoch(client *ethclient.Client, bl
 	if err != nil {
 		return nil, err
 	}
-
-	revealedDataChan := make(chan types.RevealedStruct, len(logs))
-	errorChan := make(chan error, len(logs))
-	var wg sync.WaitGroup
-
+	var revealedData []types.RevealedStruct
 	for _, vLog := range logs {
-		wg.Add(1)
-		go func(vLog Types.Log) {
-			defer wg.Done()
-			data, unpackErr := abiUtils.Unpack(contractAbi, "Revealed", vLog.Data)
-			if unpackErr != nil {
-				errorChan <- unpackErr
-				return
-			}
-
-			if epoch != data[0].(uint32) {
-				return
-			}
-
+		data, unpackErr := abiUtils.Unpack(contractAbi, "Revealed", vLog.Data)
+		if unpackErr != nil {
+			log.Debug(unpackErr)
+			continue
+		}
+		if epoch == data[0].(uint32) {
 			treeValues := data[2].([]struct {
 				LeafId uint16   `json:"leafId"`
 				Value  *big.Int `json:"value"`
@@ -171,31 +158,9 @@ func (*UtilsStruct) IndexRevealEventsOfCurrentEpoch(client *ethclient.Client, bl
 				RevealedValues: revealedValues,
 				Influence:      data[1].(*big.Int),
 			}
-
-			revealedDataChan <- consolidatedRevealedData
-		}(vLog)
-	}
-
-	wg.Wait()
-	close(revealedDataChan)
-	close(errorChan)
-
-	var revealedData []types.RevealedStruct
-	for {
-		select {
-		case data, ok := <-revealedDataChan:
-			if ok {
-				revealedData = append(revealedData, data)
-			}
-		case err, ok := <-errorChan:
-			if ok {
-				log.Debug(err)
-			}
-		}
-		if len(revealedDataChan) == 0 && len(errorChan) == 0 {
-			break
+			revealedData = append(revealedData, consolidatedRevealedData)
 		}
 	}
-
+	log.Debug("IndexRevealEventsOfCurrentEpoch: Revealed values: ", revealedData)
 	return revealedData, nil
 }

--- a/core/types/assets.go
+++ b/core/types/assets.go
@@ -29,12 +29,6 @@ type Asset struct {
 	Collection bindings.StructsCollection
 }
 
-type AssetResult struct {
-	RevealedValuesWithIndex map[uint16][]*big.Int
-	VoteWeights             map[string]*big.Int
-	InfluenceSum            map[uint16]*big.Int
-}
-
 type Locks struct {
 	Amount      *big.Int
 	UnlockAfter *big.Int

--- a/core/types/assets.go
+++ b/core/types/assets.go
@@ -55,11 +55,6 @@ type AssignedAsset struct {
 	Value  *big.Int `json:"value"`
 }
 
-type MedianResult struct {
-	LeafId uint16
-	Median *big.Int
-}
-
 type CustomJob struct {
 	URL      string `json:"URL"`
 	Name     string `json:"name"`

--- a/utils/api_test.go
+++ b/utils/api_test.go
@@ -30,7 +30,7 @@ func getAPIByteArray(index int) []byte {
 
 func TestGetDataFromAPI(t *testing.T) {
 	//postRequestInput := `{"type": "POST","url": "https://rpc.ankr.com/polygon_mumbai","body": {"jsonrpc": "2.0","method": "eth_chainId","params": [],"id": 0},"header": {"content-type": "application/json"}}`
-	sampleChainId, _ := hex.DecodeString("7b226a736f6e727063223a22322e30222c226964223a302c22726573756c74223a2230783133383831227d")
+	sampleChainId, _ := hex.DecodeString("7b226a736f6e727063223a22322e30222c22726573756c74223a223078616133376463222c226964223a307d0a")
 
 	type args struct {
 		urlStruct types.DataSourceURL
@@ -108,7 +108,7 @@ func TestGetDataFromAPI(t *testing.T) {
 			args: args{
 				urlStruct: types.DataSourceURL{
 					Type:   "POST",
-					URL:    "https://rpc.ankr.com/polygon_mumbai",
+					URL:    "https://sepolia.optimism.io",
 					Body:   map[string]interface{}{"jsonrpc": "2.0", "method": "eth_chainId", "params": nil, "id": 0},
 					Header: map[string]string{"content-type": "application/json"},
 				},
@@ -120,7 +120,7 @@ func TestGetDataFromAPI(t *testing.T) {
 			args: args{
 				urlStruct: types.DataSourceURL{
 					Type:   "POST",
-					URL:    "https://rpc.ankr.com/polygon_mumbai",
+					URL:    "https://sepolia.optimism.io",
 					Body:   map[string]interface{}{"jsonrpc": "2.0", "method": "eth_chainId", "params": nil, "id": 0},
 					Header: map[string]string{"auth": "${API_KEY}", "content-type": "application/json"},
 				},
@@ -132,7 +132,7 @@ func TestGetDataFromAPI(t *testing.T) {
 			args: args{
 				urlStruct: types.DataSourceURL{
 					Type: "POST",
-					URL:  "https://rpc.ankr.com/polygon_mumbai",
+					URL:  "https://sepolia.optimism.io",
 					Body: map[string]interface{}{"fail": func() {}, "jsonrpc": 1},
 				},
 			},


### PR DESCRIPTION
# Description

This PR reverts: 
 - Storing medians concurrently https://github.com/razor-network/oracle-node/pull/1172 
- Concurrent implementation of `GetSortedRevealedValues` https://github.com/razor-network/oracle-node/pull/1173
- Concurrent implementation of `GetBiggestStakerAndId` #1171 #1175

This PR also Tests `GetSortedRevealedValues()` extensively with accurate data.
