### PR TITLE
feat: added support for APIs responding in json array

### DIFF
--- a/utils/api.go
+++ b/utils/api.go
@@ -84,6 +84,28 @@ func makeAPIRequest(client http.Client, dataSourceURLStruct types.DataSourceURL)
 	return response, nil
 }
 
+func parseJSONData(parsedJSON interface{}, selector string) (interface{}, error) {
+	switch v := parsedJSON.(type) {
+	case map[string]interface{}: // Handling JSON object response case
+		return GetDataFromJSON(v, selector)
+
+	case []interface{}: // Handling JSON array of objects response case
+		if len(v) > 0 {
+			// The first element from JSON array is fetched
+			if elem, ok := v[0].(map[string]interface{}); ok {
+				return GetDataFromJSON(elem, selector)
+			}
+			log.Error("Element in array is not a JSON object")
+			return nil, errors.New("element in array is not a JSON object")
+		}
+		log.Error("Empty JSON array")
+		return nil, errors.New("empty JSON array")
+	default:
+		log.Error("Unexpected JSON structure")
+		return nil, errors.New("unexpected JSON structure")
+	}
+}
+
 func GetDataFromJSON(jsonObject map[string]interface{}, selector string) (interface{}, error) {
 	if selector[0] == '[' {
 		selector = "$" + selector

--- a/utils/api_test.go
+++ b/utils/api_test.go
@@ -202,6 +202,12 @@ func TestParseJSONData(t *testing.T) {
 			expected: "value2",
 		},
 		{
+			name:        "Empty JSON Object",
+			input:       `{}`,
+			selector:    "key1",
+			expectedErr: "unknown key key1",
+		},
+		{
 			name:        "Empty JSON Array",
 			input:       `[]`,
 			selector:    "key1",

--- a/utils/asset_test.go
+++ b/utils/asset_test.go
@@ -662,6 +662,16 @@ func TestGetDataToCommitFromJob(t *testing.T) {
 		Url: `{"type": "POST","url": "https://rpc.ankr.com/eth","body": {"jsonrpc":"2.0","id":7269270904970082,"method":"eth_call","params":[{"from":"0x0000000000000000000000000000000000000000","data":"0xd06ca61f0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000200000000000000000000000050de6856358cc35f3a9a57eaaa34bd4cb707d2cd0000000000000000000000008e870d67f660d95d5be530380d0ec0bd388289e1","to":"0x7a250d5630b4cf539739df2c5dacb4c659f2488d"},"latest"]},"header": {"content-type": "application/json"}, "returnType": "hexArray[1]"}`,
 	}
 
+	arrayOfObjectsJob := bindings.StructsJob{Id: 1, SelectorType: 0, Weight: 100,
+		Power: 2, Name: "ethusd_bitfinex", Selector: "last_price",
+		Url: "https://api.bitfinex.com/v1/pubticker/ethusd",
+	}
+
+	arrayOfArraysJob := bindings.StructsJob{Id: 1, SelectorType: 0, Weight: 100,
+		Power: 2, Name: "ethusd_bitfinex_v2", Selector: "last_price",
+		Url: "https://api-pub.bitfinex.com/v2/tickers?symbols=tXDCUSD",
+	}
+
 	invalidDataSourceStructJob := bindings.StructsJob{Id: 1, SelectorType: 0, Weight: 100,
 		Power: 2, Name: "ethusd_sample", Selector: "result",
 		Url: `{"type": true,"url1": {}}`,
@@ -726,6 +736,20 @@ func TestGetDataToCommitFromJob(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: false,
+		},
+		{
+			name: "Test 7: When GetDataToCommitFromJob() executes successfully for job returning response of type array of objects",
+			args: args{
+				job: arrayOfObjectsJob,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test 8: When GetDataToCommitFromJob() fails for job returning response of type arrays of arrays as element in array is not a json object",
+			args: args{
+				job: arrayOfArraysJob,
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

Added support for APIs which responds in JSON array where we fetch the first element of the JSON array for the data feed.

Fixes #1215

# How Has This Been Tested?

- Added tests with JSON and JSON array API responses covering different parsing scenarios for `parseJSONData` function.
- Added jobs for `GetDataToCommitFromJob()` which respond with different data types JSON array [supported, positive test case] and array of arrays [not supported, negative test case expects an error]
- Ran vote command with this change and checking returned values in commit state for each job.     

