### PR TITLE
refactor: updated default logFileMaxAge and logFileMaxBackups

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ docker exec -it razor-go razor setConfig --provider <rpc_provider> --alternatePr
 Example:
 
 ```
-$ ./razor setConfig --provider https://mainnet.skalenodes.com/v1/turbulent-unique-scheat --alternateProvider https://ce2m-skale.chainode.tech:10200/ --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 52 --logFileMaxAge 365
+$ ./razor setConfig --provider https://mainnet.skalenodes.com/v1/turbulent-unique-scheat --alternateProvider https://ce2m-skale.chainode.tech:10200/ --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 10 --logFileMaxAge 60
 ```
 
 Besides, setting these parameters in the config, you can use different values for these parameters in various commands. Just add the same flag to any command you want to use and the new config changes will appear for that command.

--- a/config.sh
+++ b/config.sh
@@ -45,14 +45,14 @@ if [ -z "$MAX_SIZE" ]; then
    MAX_SIZE=200
 fi
 
-read -rp "Log Files Max Backups: (52) " MAX_BACKUPS
+read -rp "Log Files Max Backups: (10) " MAX_BACKUPS
 if [ -z "$MAX_BACKUPS" ]; then
-   MAX_BACKUPS=52
+   MAX_BACKUPS=10
 fi
 
-read -rp "Log Files Max Age: (365) " MAX_AGE
+read -rp "Log Files Max Age: (60) " MAX_AGE
 if [ -z "$MAX_AGE" ]; then
-   MAX_AGE=365
+   MAX_AGE=60
 fi
 
 ALT_PROVIDER_OPTION=""

--- a/core/constants.go
+++ b/core/constants.go
@@ -42,8 +42,8 @@ const BufferStateSleepTime int32 = 2
 //Following are the default logFile parameters in config
 const (
 	DefaultLogFileMaxSize    = 200
-	DefaultLogFileMaxBackups = 52
-	DefaultLogFileMaxAge     = 365
+	DefaultLogFileMaxBackups = 10
+	DefaultLogFileMaxAge     = 60
 )
 
 //DisputeGasMultiplier is a constant gasLimitMultiplier to increase gas Limit for function `disputeCollectionIdShouldBeAbsent` and `disputeCollectionIdShouldBePresent`


### PR DESCRIPTION
# Description

The multiple backup logs file staying for a long period on system were piling up and filling good amount of space on the system which might cause memory issues, so there was a need to reduce `logFileMaxAge` and `logFileMaxBackups`.

Fixes #1219

# Changes

Updated the default config parameters to 
```
DefaultLogFileMaxBackups = 10
DefaultLogFileMaxAge     = 60
```
