### PR TITLE
refactor: created the local cache instance only once

### DIFF
--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -16,7 +16,6 @@ import (
 	"razor/utils"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestCommit(t *testing.T) {
@@ -226,7 +225,7 @@ func TestHandleCommitState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			localCache := cache.NewLocalCache(time.Second * 10)
+			localCache := cache.NewLocalCache()
 			commitParams := &types.CommitParams{
 				LocalCache: localCache,
 			}
@@ -396,7 +395,7 @@ func BenchmarkHandleCommitState(b *testing.B) {
 	for _, v := range table {
 		b.Run(fmt.Sprintf("Number_Of_Active_Collections%d", v.numActiveCollections), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				localCache := cache.NewLocalCache(time.Second * 10)
+				localCache := cache.NewLocalCache()
 				commitParams := &types.CommitParams{
 					LocalCache: localCache,
 				}

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"razor/accounts"
+	"razor/cache"
 	"razor/core"
 	"razor/core/types"
 	"razor/logger"
@@ -118,6 +119,7 @@ func (*UtilsStruct) ExecuteVote(flagSet *pflag.FlagSet) {
 	utils.CheckError("Error in initializing asset cache: ", err)
 
 	commitParams := &types.CommitParams{
+		LocalCache:                cache.NewLocalCache(), // Creating a local cache which will store API results
 		JobsCache:                 jobsCache,
 		CollectionsCache:          collectionsCache,
 		HttpClient:                httpClient,
@@ -421,6 +423,9 @@ func (*UtilsStruct) InitiateCommit(client *ethclient.Client, config types.Config
 		log.Debug("Updating GlobalCommitDataStruct with latest commitData and epoch...")
 		updateGlobalCommitDataStruct(commitData, epoch)
 		log.Debugf("InitiateCommit: Global commit data struct: %+v", globalCommitDataStruct)
+
+		log.Debug("Clearing up the cache storing API results after successful commit...")
+		commitParams.LocalCache.ClearAll()
 	}
 	return nil
 }

--- a/cmd/vote_test.go
+++ b/cmd/vote_test.go
@@ -345,6 +345,7 @@ func TestInitiateCommit(t *testing.T) {
 	)
 
 	commitParams := &types.CommitParams{
+		LocalCache:                cache.NewLocalCache(),
 		JobsCache:                 cache.NewJobsCache(),
 		CollectionsCache:          cache.NewCollectionsCache(),
 		FromBlockToCheckForEvents: big.NewInt(1),

--- a/utils/api.go
+++ b/utils/api.go
@@ -36,7 +36,7 @@ func GetDataFromAPI(commitParams *types.CommitParams, dataSourceURLStruct types.
 		return nil, err
 	}
 
-	// Storing the data into cache
+	// Storing the API results data into cache
 	commitParams.LocalCache.Update(response, cacheKey, time.Now().Add(time.Second*time.Duration(core.StateLength)).Unix())
 	return response, nil
 }

--- a/utils/api_test.go
+++ b/utils/api_test.go
@@ -178,7 +178,7 @@ func TestGetDataFromAPI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			localCache := cache.NewLocalCache(time.Second * 10)
+			localCache := cache.NewLocalCache()
 			commitParams := &types.CommitParams{
 				LocalCache: localCache,
 				HttpClient: httpClient,

--- a/utils/asset_test.go
+++ b/utils/asset_test.go
@@ -644,7 +644,7 @@ func TestGetDataToCommitFromJobs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			UtilsInterface = &UtilsStruct{}
 			commitParams := &types.CommitParams{
-				LocalCache: cache.NewLocalCache(time.Second * 10),
+				LocalCache: cache.NewLocalCache(),
 				HttpClient: httpClient,
 			}
 
@@ -787,7 +787,7 @@ func TestGetDataToCommitFromJob(t *testing.T) {
 			utils := StartRazor(optionsPackageStruct)
 
 			commitParams := &types.CommitParams{
-				LocalCache: cache.NewLocalCache(time.Second * 10),
+				LocalCache: cache.NewLocalCache(),
 				HttpClient: httpClient,
 			}
 


### PR DESCRIPTION
# Description

 Created the local cache storing API results only once.

Fixes https://linear.app/interstellar-research/issue/RAZ-981

# How Has This Been Tested?

- Ran a staker with successful and failed commit state scenarios such that the retry attempt to fetch data from APIs is done from cache.
- Ran a staker with assigned collections having duplicate jobs, fetching the other job from cache.