### PR TITLE
chore: update default wait time in config.sh

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -25,9 +25,9 @@ then
   BUFFER=5
 fi
 
-read -rp "Wait Time: (5) " WAIT_TIME
+read -rp "Wait Time: (1) " WAIT_TIME
 if [ -z "$WAIT_TIME" ]; then
-   WAIT_TIME=5
+   WAIT_TIME=1
 fi
 
 read -rp "Gas Price: (1) " GAS_PRICE


### PR DESCRIPTION
# Description

As the default value for wait time was updated in PR #1232 for shorter 5 min epoch, we need to update the same in config.sh. This PR does the same.

Fixes https://linear.app/interstellar-research/issue/RAZ-758
