### PR TITLE
hotfix: update artifact actions to latest versions in GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           mv razor_go.linux-amd64.tar.gz ../../
 
       - name: Upload AMD Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: razor_go.linux-amd64.tar.gz
           path: razor_go.linux-amd64.tar.gz
@@ -173,7 +173,7 @@ jobs:
           mv razor_go.linux-arm64.tar.gz ../../
 
       - name: Upload ARM Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: razor_go.linux-arm64.tar.gz
           path: razor_go.linux-arm64.tar.gz
@@ -197,12 +197,12 @@ jobs:
           node-version: "18"
 
       - name: Download Artifacts AMD
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: razor_go.linux-amd64.tar.gz
 
       - name: Download Artifacts ARM
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: razor_go.linux-arm64.tar.gz
 


### PR DESCRIPTION
# Description

This PR updates the deprecated `actions/upload-artifact@v2` and `actions/download-artifact@v2` to the latest supported versions, `actions/upload-artifact@v3` and `actions/download-artifact@v3`, in the GitHub workflow.

Fixes https://linear.app/interstellar-research/issue/RAZ-1000
