### PR TITLE
hotfix: updated retry parameters and default timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker network create razor_network
 2. Start razor-go container
 
 ```
-docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v1.0.0-mainnet
+docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v2.0.0
 ```
 
 > **_NOTE:_** We leverage Docker bind-mounts to mount the .razor directory, ensuring a shared mount between the host and the container. The `.razor` directory holds keys to the addresses that we use in `razor-go`, along with logs and config. We do this to persist data in the host machine, otherwise you would lose your keys once you delete the container.
@@ -124,7 +124,7 @@ docker exec -it razor-go razor setConfig --provider <rpc_provider> --alternatePr
 Example:
 
 ```
-$ ./razor setConfig --provider https://mainnet.skalenodes.com/v1/turbulent-unique-scheat --alternateProvider https://ce2m-skale.chainode.tech:10200/ --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 10 --logFileMaxAge 60
+$ ./razor setConfig --provider https://mainnet.skalenodes.com/v1/elated-tan-skat --gasmultiplier 1 --buffer 5 --wait 1 --gasprice 0 --logLevel debug --gasLimit 2 --rpcTimeout 5 --httpTimeout 5 --logFileMaxSize 200 --logFileMaxBackups 10 --logFileMaxAge 60
 ```
 
 Besides, setting these parameters in the config, you can use different values for these parameters in various commands. Just add the same flag to any command you want to use and the new config changes will appear for that command.
@@ -132,7 +132,7 @@ Besides, setting these parameters in the config, you can use different values fo
 Example:
 
 ```
-$ ./razor vote --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --gasprice 10
+$ ./razor vote --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --gasprice 1
 ```
 
 This will cause this particular vote command to run with a gas price of 10.

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -345,8 +345,8 @@ func (*UtilsStruct) GetRPCTimeout() (int64, error) {
 
 func (*UtilsStruct) GetHTTPTimeout() (int64, error) {
 	const (
-		MinHTTPTimeout = 10 // Minimum HTTP timeout in seconds
-		MaxHTTPTimeout = 20 // Maximum HTTP timeout in seconds
+		MinHTTPTimeout = 5 // Minimum HTTP timeout in seconds
+		MaxHTTPTimeout = 8 // Maximum HTTP timeout in seconds
 	)
 
 	httpTimeout, err := getConfigValue("httpTimeout", "int64", core.DefaultHTTPTimeout, "httpTimeout")

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -323,8 +323,8 @@ func (*UtilsStruct) GetGasLimitOverride() (uint64, error) {
 //This function returns the RPC timeout
 func (*UtilsStruct) GetRPCTimeout() (int64, error) {
 	const (
-		MinRPCTimeout = 10 // Minimum RPC timeout in seconds
-		MaxRPCTimeout = 20 // Maximum RPC timeout in seconds
+		MinRPCTimeout = 5  // Minimum RPC timeout in seconds
+		MaxRPCTimeout = 10 // Maximum RPC timeout in seconds
 	)
 
 	rpcTimeout, err := getConfigValue("rpcTimeout", "int64", core.DefaultRPCTimeout, "rpcTimeout")

--- a/cmd/config-utils_test.go
+++ b/cmd/config-utils_test.go
@@ -955,9 +955,9 @@ func TestGetRPCTimeout(t *testing.T) {
 			name: "Test 1: When rpcTimeout is fetched from root flag",
 			args: args{
 				isFlagSet:  true,
-				rpcTimeout: 12,
+				rpcTimeout: 6,
 			},
-			want:    12,
+			want:    6,
 			wantErr: nil,
 		},
 		{
@@ -973,9 +973,9 @@ func TestGetRPCTimeout(t *testing.T) {
 			name:               "Test 3: When rpcTimeout value is fetched from config",
 			useDummyConfigFile: true,
 			args: args{
-				rpcTimeoutInTestConfig: 20,
+				rpcTimeoutInTestConfig: 7,
 			},
-			want:    20,
+			want:    7,
 			wantErr: nil,
 		},
 		{
@@ -1043,9 +1043,9 @@ func TestGetHTTPTimeout(t *testing.T) {
 			name: "Test 1: When httpTimeout is fetched from root flag",
 			args: args{
 				isFlagSet:   true,
-				httpTimeout: 12,
+				httpTimeout: 6,
 			},
-			want:    12,
+			want:    6,
 			wantErr: nil,
 		},
 		{
@@ -1061,9 +1061,9 @@ func TestGetHTTPTimeout(t *testing.T) {
 			name:               "Test 3: When httpTimeout value is fetched from config",
 			useDummyConfigFile: true,
 			args: args{
-				httpTimeoutInTestConfig: 20,
+				httpTimeoutInTestConfig: 7,
 			},
-			want:    20,
+			want:    7,
 			wantErr: nil,
 		},
 		{

--- a/cmd/setConfig.go
+++ b/cmd/setConfig.go
@@ -19,7 +19,7 @@ var setConfig = &cobra.Command{
 Setting the gas multiplier value enables the CLI to multiply the gas with that value for all the transactions
 
 Example:
-  ./razor setConfig --provider https://infura/v3/matic --gasmultiplier 1.5 --buffer 20 --wait 70 --gasprice 1 --logLevel debug --gasLimit 5
+  ./razor setConfig --provider https://mainnet.skalenodes.com/v1/elated-tan-skat --gasmultiplier 1 --buffer 5 --wait 1 --gasprice 0 --logLevel debug --gasLimit 2
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := cmdUtils.SetConfig(cmd.Flags())

--- a/config.sh
+++ b/config.sh
@@ -60,4 +60,4 @@ if [ -n "$ALTERNATE_PROVIDER" ]; then
     ALT_PROVIDER_OPTION="--alternateProvider $ALTERNATE_PROVIDER"
 fi
 
-$RAZOR setConfig -p $PROVIDER $ALT_PROVIDER_OPTION -b $BUFFER -g $GAS_MULTIPLIER -w $WAIT_TIME --gasprice $GAS_PRICE --gasLimit $GAS_LIMIT --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize $MAX_SIZE --logFileMaxBackups $MAX_BACKUPS --logFileMaxAge $MAX_AGE
+$RAZOR setConfig -p $PROVIDER $ALT_PROVIDER_OPTION -b $BUFFER -g $GAS_MULTIPLIER -w $WAIT_TIME --gasprice $GAS_PRICE --gasLimit $GAS_LIMIT --rpcTimeout 5 --httpTimeout 5 --logFileMaxSize $MAX_SIZE --logFileMaxBackups $MAX_BACKUPS --logFileMaxAge $MAX_AGE

--- a/core/constants.go
+++ b/core/constants.go
@@ -31,7 +31,7 @@ const (
 	DefaultWaitTime         int32   = 1
 	DefaultGasLimit         float32 = 2
 	DefaultGasLimitOverride uint64  = 30000000
-	DefaultRPCTimeout       int64   = 10
+	DefaultRPCTimeout       int64   = 5
 	DefaultHTTPTimeout      int64   = 5
 	DefaultLogLevel                 = ""
 )

--- a/core/constants.go
+++ b/core/constants.go
@@ -32,7 +32,7 @@ const (
 	DefaultGasLimit         float32 = 2
 	DefaultGasLimitOverride uint64  = 30000000
 	DefaultRPCTimeout       int64   = 10
-	DefaultHTTPTimeout      int64   = 10
+	DefaultHTTPTimeout      int64   = 5
 	DefaultLogLevel                 = ""
 )
 

--- a/core/constants.go
+++ b/core/constants.go
@@ -17,7 +17,10 @@ const (
 // ChainId corresponds to the EUROPA chain
 var ChainId = big.NewInt(0x79f99296)
 
-const MaxRetries uint = 8
+const (
+	MaxRetries         uint  = 3
+	RetryDelayDuration int64 = 1
+)
 
 var NilHash = common.Hash{0x00}
 

--- a/core/constants.go
+++ b/core/constants.go
@@ -24,7 +24,10 @@ const (
 
 var NilHash = common.Hash{0x00}
 
-const BlockCompletionTimeout = 20
+const (
+	BlockCompletionAttempts          = 3
+	BlockCompletionAttemptRetryDelay = 1
+)
 
 //Following are the default config values for all the config parameters
 const (

--- a/core/constants.go
+++ b/core/constants.go
@@ -24,7 +24,7 @@ const (
 
 var NilHash = common.Hash{0x00}
 
-const BlockCompletionTimeout = 30
+const BlockCompletionTimeout = 20
 
 //Following are the default config values for all the config parameters
 const (

--- a/utils/common.go
+++ b/utils/common.go
@@ -89,7 +89,7 @@ func (*UtilsStruct) WaitForBlockCompletion(client *ethclient.Client, hashToRead 
 			log.Info("Transaction mined successfully")
 			return nil
 		}
-		Time.Sleep(3 * time.Second)
+		Time.Sleep(2 * time.Second)
 	}
 	log.Info("Timeout Passed")
 	return errors.New("timeout passed for transaction mining")

--- a/utils/common.go
+++ b/utils/common.go
@@ -77,8 +77,7 @@ func (*UtilsStruct) CheckTransactionReceipt(client *ethclient.Client, _txHash st
 }
 
 func (*UtilsStruct) WaitForBlockCompletion(client *ethclient.Client, hashToRead string) error {
-	timeout := core.BlockCompletionTimeout
-	for start := time.Now(); time.Since(start) < time.Duration(timeout)*time.Second; {
+	for i := 0; i < core.BlockCompletionAttempts; i++ {
 		log.Debug("Checking if transaction is mined....")
 		transactionStatus := UtilsInterface.CheckTransactionReceipt(client, hashToRead)
 		if transactionStatus == 0 {
@@ -89,10 +88,10 @@ func (*UtilsStruct) WaitForBlockCompletion(client *ethclient.Client, hashToRead 
 			log.Info("Transaction mined successfully")
 			return nil
 		}
-		Time.Sleep(2 * time.Second)
+		Time.Sleep(core.BlockCompletionAttemptRetryDelay * time.Second)
 	}
-	log.Info("Timeout Passed")
-	return errors.New("timeout passed for transaction mining")
+	log.Info("Max retries for WaitForBlockCompletion attempted!")
+	return errors.New("maximum attempts failed for transaction mining")
 }
 
 func (*UtilsStruct) WaitTillNextNSecs(waitTime int32) {

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -605,7 +605,7 @@ func TestWaitForBlockCompletion(t *testing.T) {
 			args: args{
 				transactionStatus: 2,
 			},
-			want: errors.New("timeout passed for transaction mining"),
+			want: errors.New("maximum attempts failed for transaction mining"),
 		},
 	}
 	for _, tt := range tests {

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -134,7 +134,7 @@ func InvokeFunctionWithRetryAttempts(interfaceName interface{}, methodName strin
 				return err
 			}
 			return nil
-		}, RetryInterface.RetryAttempts(core.MaxRetries))
+		}, RetryInterface.RetryAttempts(core.MaxRetries), retry.Delay(time.Second*time.Duration(core.RetryDelayDuration)))
 	if err != nil {
 		if !switchToAlternateClient && alternateProvider != "" {
 			log.Errorf("%v error after retries: %v", methodName, err)

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -134,7 +134,7 @@ func InvokeFunctionWithRetryAttempts(interfaceName interface{}, methodName strin
 				return err
 			}
 			return nil
-		}, RetryInterface.RetryAttempts(core.MaxRetries), retry.Delay(time.Second*time.Duration(core.RetryDelayDuration)))
+		}, RetryInterface.RetryAttempts(core.MaxRetries), retry.Delay(time.Second*time.Duration(core.RetryDelayDuration)), retry.DelayType(retry.FixedDelay))
 	if err != nil {
 		if !switchToAlternateClient && alternateProvider != "" {
 			log.Errorf("%v error after retries: %v", methodName, err)


### PR DESCRIPTION
# Description

- Default timeout for unresponsive HTTP and RPC calls were higher for a 5 min epoch causing a node to pass the state time, have reduced in this PR.

- Updated retry parameters in retry implementation for RPC calls.
- Made `waitForCompletion` function to run for fixed attempts with fixed delay in between each attempt.
- Correct RPC and config values in readme

Fixes https://linear.app/interstellar-research/issue/RAZ-1013
