### PR TITLE
fix: enabled setting 0 commission for updateCommission command

### DIFF
--- a/cmd/updateCommission.go
+++ b/cmd/updateCommission.go
@@ -89,7 +89,7 @@ func (*UtilsStruct) UpdateCommission(config types.Configurations, client *ethcli
 	}
 	log.Debug("UpdateCommission: Maximum Commission: ", maxCommission)
 
-	if updateCommissionInput.Commission == 0 || updateCommissionInput.Commission > maxCommission {
+	if updateCommissionInput.Commission > maxCommission {
 		return errors.New("commission out of range")
 	}
 
@@ -159,4 +159,7 @@ func init() {
 
 	addrErr := updateCommissionCmd.MarkFlagRequired("address")
 	utils.CheckError("Address error: ", addrErr)
+
+	commissionErr := updateCommissionCmd.MarkFlagRequired("commission")
+	utils.CheckError("Commission error: ", commissionErr)
 }

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -138,7 +138,7 @@ func TestUpdateCommission(t *testing.T) {
 				UpdateCommissionTxn:           &Types.Transaction{},
 				UpdateCommissionErr:           nil,
 			},
-			wantErr: errors.New("commission out of range"),
+			wantErr: nil,
 		},
 		{
 			name: "Test 8: When commission is greater than max commission",


### PR DESCRIPTION
# Description

Commission can be set to 0 in update commission transaction from contracts.
So this PR removes the existing commission zero check in `updateCommission` command which will enable the node now to set 0 commission via `updateCommission` command.

- Made the `commission` flag required which will make mandatory to pass commission value now.
- Passing commission as 0 would be accepted for update commission transaction now.

Fixes https://linear.app/interstellar-research/issue/RAZ-1032
