### PR TITLE
refactor: replaced SKL with sFuel as a gas token in logs

### DIFF
--- a/cmd/addStake.go
+++ b/cmd/addStake.go
@@ -69,7 +69,7 @@ func (*UtilsStruct) ExecuteStake(flagSet *pflag.FlagSet) {
 	log.Debug("Checking for sufficient balance...")
 	razorUtils.CheckAmountAndBalance(valueInWei, balance)
 
-	log.Debug("Checking whether sFuel balance is not 0...")
+	log.Debug("Checking whether sFUEL balance is not 0...")
 	razorUtils.CheckEthBalanceIsZero(context.Background(), client, address)
 
 	minSafeRazor, err := razorUtils.GetMinSafeRazor(context.Background(), client)

--- a/cmd/delegate.go
+++ b/cmd/delegate.go
@@ -73,7 +73,7 @@ func (*UtilsStruct) ExecuteDelegate(flagSet *pflag.FlagSet) {
 	log.Debug("Checking for sufficient balance...")
 	razorUtils.CheckAmountAndBalance(valueInWei, balance)
 
-	log.Debug("Checking whether sFuel balance is not 0...")
+	log.Debug("Checking whether sFUEL balance is not 0...")
 	razorUtils.CheckEthBalanceIsZero(context.Background(), client, address)
 
 	txnArgs := types.TransactionOptions{

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -231,9 +231,9 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 		return
 	}
 
-	// Warning the staker if sFuel balance is less than 0.001 sFuel
+	// Warning the staker if sFUEL balance is less than 0.001 sFUEL
 	if ethBalance.Cmp(big.NewInt(1e15)) == -1 {
-		log.Warn("sFuel balance is lower than 0.001 sFuel, kindly add more sFuel to be safe for executing transactions successfully")
+		log.Warn("sFUEL balance is lower than 0.001 sFUEL, kindly add more sFUEL to be safe for executing transactions successfully")
 	}
 
 	actualStake, err := utils.ConvertWeiToEth(stakedAmount)
@@ -264,7 +264,7 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 		}
 	}
 
-	log.Infof("State: %s Staker ID: %d Stake: %f sRZR Balance: %f sFuel Balance: %f", utils.GetStateName(state), stakerId, actualStake, sRZRInEth, actualBalance)
+	log.Infof("State: %s Staker ID: %d Stake: %f sRZR Balance: %f sFUEL Balance: %f", utils.GetStateName(state), stakerId, actualStake, sRZRInEth, actualBalance)
 
 	if staker.IsSlashed {
 		log.Error("Staker is slashed.... cannot continue to vote!")

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -231,9 +231,9 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 		return
 	}
 
-	// Warning the staker if ETH balance is less than 0.1 ETH
-	if ethBalance.Cmp(big.NewInt(1e17)) == -1 {
-		log.Warn("sFuel balance is lower than 0.1 sFuel, kindly add more SKL to be safe for executing transactions successfully")
+	// Warning the staker if sFuel balance is less than 0.001 sFuel
+	if ethBalance.Cmp(big.NewInt(1e15)) == -1 {
+		log.Warn("sFuel balance is lower than 0.001 sFuel, kindly add more sFuel to be safe for executing transactions successfully")
 	}
 
 	actualStake, err := utils.ConvertWeiToEth(stakedAmount)

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -233,7 +233,7 @@ func (*UtilsStruct) HandleBlock(client *ethclient.Client, account types.Account,
 
 	// Warning the staker if ETH balance is less than 0.1 ETH
 	if ethBalance.Cmp(big.NewInt(1e17)) == -1 {
-		log.Warn("sFuel balance is lower than 0.1 SKL, kindly add more SKL to be safe for executing transactions successfully")
+		log.Warn("sFuel balance is lower than 0.1 sFuel, kindly add more SKL to be safe for executing transactions successfully")
 	}
 
 	actualStake, err := utils.ConvertWeiToEth(stakedAmount)

--- a/utils/common.go
+++ b/utils/common.go
@@ -118,10 +118,10 @@ func (*UtilsStruct) IsFlagPassed(name string) bool {
 func (*UtilsStruct) CheckEthBalanceIsZero(ctx context.Context, client *ethclient.Client, address string) {
 	ethBalance, err := ClientInterface.BalanceAtWithRetry(ctx, client, common.HexToAddress(address))
 	if err != nil {
-		log.Fatalf("Error in fetching sFuel balance of the account: %s\n%s", address, err)
+		log.Fatalf("Error in fetching sFUEL balance of the account: %s\n%s", address, err)
 	}
 	if ethBalance.Cmp(big.NewInt(0)) == 0 {
-		log.Fatal("sFuel balance is 0, Aborting...")
+		log.Fatal("sFUEL balance is 0, Aborting...")
 	}
 }
 


### PR DESCRIPTION
# Description

Currently SKL is being logged as  gas token, SKL is never used as an gas ans sfuel and the SKL token are different.
Replaced SKL with sFuel in logs. 