### PR TITLE
chore: updated retry parameters to check transaction mined status

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -25,8 +25,8 @@ const (
 var NilHash = common.Hash{0x00}
 
 const (
-	BlockCompletionAttempts          = 3
-	BlockCompletionAttemptRetryDelay = 1
+	BlockCompletionAttempts          = 4
+	BlockCompletionAttemptRetryDelay = 2
 )
 
 //Following are the default config values for all the config parameters

--- a/core/constants.go
+++ b/core/constants.go
@@ -27,6 +27,7 @@ var NilHash = common.Hash{0x00}
 const (
 	BlockCompletionAttempts          = 4
 	BlockCompletionAttemptRetryDelay = 2
+	BlockCompletionTimeout           = 15
 )
 
 //Following are the default config values for all the config parameters


### PR DESCRIPTION
# Description

Current Behavior: The node was reporting transactions as failed because the timeout for checking the transaction status was too short compared to the time required for a transaction to be confirmed. While this is not an issue as mined status is not serving any major purpose, it is a suggested improvement to enhance the user experience.

Proposed Changes: Increased the number of retries and the delay between them to extend the interval for checking the transaction status. The interval has been increased from `3 seconds` to `8 seconds` to allow more time for checking the transaction to be mined.

Fixes https://linear.app/interstellar-research/issue/RAZ-1038

