### PR TITLE
fix: added context parameter to functions to sync with updated generic retry function to make build successful

### DIFF
--- a/cmd/collectionList.go
+++ b/cmd/collectionList.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"razor/logger"
@@ -46,7 +47,7 @@ func (*UtilsStruct) ExecuteCollectionList(flagSet *pflag.FlagSet) {
 
 //This function provides the list of all collections with their name, power, ID etc.
 func (*UtilsStruct) GetCollectionList(client *ethclient.Client) error {
-	collections, err := razorUtils.GetAllCollections(client)
+	collections, err := razorUtils.GetAllCollections(context.Background(), client)
 	log.Debugf("GetCollectionList: Collections: %+v", collections)
 
 	if err != nil {

--- a/cmd/collectionList_test.go
+++ b/cmd/collectionList_test.go
@@ -72,7 +72,7 @@ func TestGetCollectionList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetAllCollections", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.collectionList, tt.args.collectionListErr)
+			utilsMock.On("GetAllCollections", mock.Anything, mock.Anything).Return(tt.args.collectionList, tt.args.collectionListErr)
 			utils := &UtilsStruct{}
 
 			err := utils.GetCollectionList(tt.args.client)

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -57,7 +57,7 @@ HandleCommitState fetches the collections assigned to the staker and creates the
 Values for only the collections assigned to the staker is fetched for others, 0 is added to the leaves of tree.
 */
 func (*UtilsStruct) HandleCommitState(ctx context.Context, client *ethclient.Client, epoch uint32, seed []byte, commitParams *types.CommitParams, rogueData types.Rogue) (types.CommitData, error) {
-	numActiveCollections, err := razorUtils.GetNumActiveCollections(client)
+	numActiveCollections, err := razorUtils.GetNumActiveCollections(ctx, client)
 	if err != nil {
 		return types.CommitData{}, err
 	}
@@ -89,7 +89,7 @@ func (*UtilsStruct) HandleCommitState(ctx context.Context, client *ethclient.Cli
 
 			log.Debugf("HandleCommitState: Is the collection at iterating index %v assigned: %v ", i, assignedCollections[i])
 			if assignedCollections[i] {
-				collectionId, err := razorUtils.GetCollectionIdFromIndex(client, uint16(i))
+				collectionId, err := razorUtils.GetCollectionIdFromIndex(ctx, client, uint16(i))
 				if err != nil {
 					log.Error("Error in getting collection ID: ", err)
 					errChan <- err

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -404,9 +404,9 @@ func BenchmarkHandleCommitState(b *testing.B) {
 
 				SetUpMockInterfaces()
 
-				utilsMock.On("GetNumActiveCollections", mock.AnythingOfType("*ethclient.Client")).Return(v.numActiveCollections, nil)
+				utilsMock.On("GetNumActiveCollections", mock.Anything, mock.Anything).Return(v.numActiveCollections, nil)
 				utilsMock.On("GetAssignedCollections", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(v.assignedCollections, nil, nil)
-				utilsMock.On("GetCollectionIdFromIndex", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(uint16(1), nil)
+				utilsMock.On("GetCollectionIdFromIndex", mock.Anything, mock.Anything, mock.Anything).Return(uint16(1), nil)
 				utilsMock.On("GetAggregatedDataOfCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(1000), nil)
 				utilsMock.On("GetRogueRandomValue", mock.Anything).Return(rogueValue)
 

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -234,9 +234,9 @@ func TestHandleCommitState(t *testing.T) {
 
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetNumActiveCollections", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.numActiveCollections, tt.args.numActiveCollectionsErr)
+			utilsMock.On("GetNumActiveCollections", mock.Anything, mock.Anything).Return(tt.args.numActiveCollections, tt.args.numActiveCollectionsErr)
 			utilsMock.On("GetAssignedCollections", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.assignedCollections, tt.args.seqAllottedCollections, tt.args.assignedCollectionsErr)
-			utilsMock.On("GetCollectionIdFromIndex", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.collectionId, tt.args.collectionIdErr)
+			utilsMock.On("GetCollectionIdFromIndex", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.collectionId, tt.args.collectionIdErr)
 			utilsMock.On("GetAggregatedDataOfCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.collectionData, tt.args.collectionDataErr)
 			utilsMock.On("GetRogueRandomValue", mock.Anything).Return(rogueValue)
 

--- a/cmd/dispute.go
+++ b/cmd/dispute.go
@@ -165,7 +165,7 @@ func (*UtilsStruct) HandleDispute(ctx context.Context, client *ethclient.Client,
 
 				sortedValues := revealedDataMaps.SortedRevealedValues[collectionIdOfWrongMedian-1]
 				log.Debug("HandleDispute: Sorted values: ", sortedValues)
-				leafId, err := razorUtils.GetLeafIdOfACollection(client, collectionIdOfWrongMedian)
+				leafId, err := razorUtils.GetLeafIdOfACollection(ctx, client, collectionIdOfWrongMedian)
 				if err != nil {
 					log.Error("Error in leaf id: ", err)
 					continue
@@ -369,7 +369,7 @@ func (*UtilsStruct) Dispute(ctx context.Context, client *ethclient.Client, confi
 		giveSortedLeafIds = append(giveSortedLeafIds, int(leafId))
 	}
 	log.Debugf("Dispute: Calling GetCollectionIdPositionInBlock with arguments leafId = %d, proposed block = %+v", leafId, proposedBlock)
-	positionOfCollectionInBlock := cmdUtils.GetCollectionIdPositionInBlock(client, leafId, proposedBlock)
+	positionOfCollectionInBlock := cmdUtils.GetCollectionIdPositionInBlock(ctx, client, leafId, proposedBlock)
 	log.Debug("Dispute: Position of collection id in block: ", positionOfCollectionInBlock)
 
 	log.Info("Finalizing dispute...")
@@ -464,9 +464,9 @@ func GiveSorted(ctx context.Context, client *ethclient.Client, blockManager *bin
 }
 
 //This function returns the collection Id position in block
-func (*UtilsStruct) GetCollectionIdPositionInBlock(client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int {
+func (*UtilsStruct) GetCollectionIdPositionInBlock(ctx context.Context, client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int {
 	ids := proposedBlock.Ids
-	idToBeDisputed, err := razorUtils.GetCollectionIdFromLeafId(client, leafId)
+	idToBeDisputed, err := razorUtils.GetCollectionIdFromLeafId(ctx, client, leafId)
 	if err != nil {
 		log.Error("Error in fetching collection id from leaf id")
 		return nil

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -96,7 +96,7 @@ func TestDispute(t *testing.T) {
 			utilsMock.On("GetBlockManager", mock.AnythingOfType("*ethclient.Client")).Return(blockManager)
 			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(TxnOpts)
 			cmdUtilsMock.On("GiveSorted", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-			cmdUtilsMock.On("GetCollectionIdPositionInBlock", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.positionOfCollectionInBlock)
+			cmdUtilsMock.On("GetCollectionIdPositionInBlock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.positionOfCollectionInBlock)
 			blockManagerMock.On("FinalizeDispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.finalizeDisputeTxn, tt.args.finalizeDisputeErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 			cmdUtilsMock.On("StoreBountyId", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.storeBountyIdErr)
@@ -538,7 +538,7 @@ func TestHandleDispute(t *testing.T) {
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.Hash)
 			utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(nil)
 			cmdUtilsMock.On("CheckDisputeForIds", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.idDisputeTxn, tt.args.idDisputeTxnErr)
-			utilsMock.On("GetLeafIdOfACollection", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.leafId, tt.args.leafIdErr)
+			utilsMock.On("GetLeafIdOfACollection", mock.Anything, mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.leafId, tt.args.leafIdErr)
 			cmdUtilsMock.On("Dispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.disputeErr)
 			utilsMock.On("GetBlockManager", mock.AnythingOfType("*ethclient.Client")).Return(blockManager)
 			cmdUtilsMock.On("StoreBountyId", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.storeBountyIdErr)
@@ -864,9 +864,9 @@ func TestGetCollectionIdPositionInBlock(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetCollectionIdFromLeafId", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.idToBeDisputed, tt.args.idToBeDisputedErr)
+			utilsMock.On("GetCollectionIdFromLeafId", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.idToBeDisputed, tt.args.idToBeDisputedErr)
 			ut := &UtilsStruct{}
-			if got := ut.GetCollectionIdPositionInBlock(client, leafId, tt.args.proposedBlock); !reflect.DeepEqual(got, tt.want) {
+			if got := ut.GetCollectionIdPositionInBlock(context.Background(), client, leafId, tt.args.proposedBlock); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetCollectionIdPositionInBlock() = %v, want %v", got, tt.want)
 			}
 		})
@@ -1153,9 +1153,9 @@ func BenchmarkGetCollectionIdPositionInBlock(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				SetUpMockInterfaces()
 
-				utilsMock.On("GetCollectionIdFromLeafId", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(v.idToBeDisputed, nil)
+				utilsMock.On("GetCollectionIdFromLeafId", mock.Anything, mock.Anything, mock.Anything).Return(v.idToBeDisputed, nil)
 				ut := &UtilsStruct{}
-				ut.GetCollectionIdPositionInBlock(client, leafId, bindings.StructsBlock{Ids: getDummyIds(v.numOfIds)})
+				ut.GetCollectionIdPositionInBlock(context.Background(), client, leafId, bindings.StructsBlock{Ids: getDummyIds(v.numOfIds)})
 			}
 		})
 	}
@@ -1212,7 +1212,7 @@ func BenchmarkHandleDispute(b *testing.B) {
 				transactionMock.On("Hash", mock.Anything).Return(common.BigToHash(big.NewInt(1)))
 				utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(nil)
 				cmdUtilsMock.On("CheckDisputeForIds", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&Types.Transaction{}, nil)
-				utilsMock.On("GetLeafIdOfACollection", mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+				utilsMock.On("GetLeafIdOfACollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 				cmdUtilsMock.On("Dispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				utilsMock.On("GetBlockManager", mock.AnythingOfType("*ethclient.Client")).Return(blockManager)
 				cmdUtilsMock.On("StoreBountyId", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -1212,7 +1212,7 @@ func BenchmarkHandleDispute(b *testing.B) {
 				transactionMock.On("Hash", mock.Anything).Return(common.BigToHash(big.NewInt(1)))
 				utilsMock.On("WaitForBlockCompletion", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("string")).Return(nil)
 				cmdUtilsMock.On("CheckDisputeForIds", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&Types.Transaction{}, nil)
-				utilsMock.On("GetLeafIdOfACollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
+				utilsMock.On("GetLeafIdOfACollection", mock.Anything, mock.Anything, mock.Anything).Return(0, nil)
 				cmdUtilsMock.On("Dispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				utilsMock.On("GetBlockManager", mock.AnythingOfType("*ethclient.Client")).Return(blockManager)
 				cmdUtilsMock.On("StoreBountyId", mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/cmd/eventListeners.go
+++ b/cmd/eventListeners.go
@@ -31,7 +31,7 @@ func (*UtilsStruct) InitJobAndCollectionCache(ctx context.Context, client *ethcl
 	collectionsCache := cache.NewCollectionsCache()
 
 	// Initialize caches
-	if err := utils.InitJobsCache(client, jobsCache); err != nil {
+	if err := utils.InitJobsCache(ctx, client, jobsCache); err != nil {
 		log.Error("Error in initializing jobs cache: ", err)
 		return nil, nil, nil, err
 	}
@@ -87,7 +87,7 @@ func processEvents(ctx context.Context, client *ethclient.Client, contractABI ab
 				switch eventName {
 				case core.JobUpdatedEvent, core.JobCreatedEvent:
 					jobId := utils.ConvertHashToUint16(vLog.Topics[1])
-					updatedJob, err := utils.UtilsInterface.GetActiveJob(client, jobId)
+					updatedJob, err := utils.UtilsInterface.GetActiveJob(ctx, client, jobId)
 					if err != nil {
 						log.Errorf("Error in getting job with job Id %v: %v", jobId, err)
 						continue
@@ -96,7 +96,7 @@ func processEvents(ctx context.Context, client *ethclient.Client, contractABI ab
 					jobsCache.UpdateJob(jobId, updatedJob)
 				case core.CollectionUpdatedEvent, core.CollectionCreatedEvent, core.CollectionActivityStatusEvent:
 					collectionId := utils.ConvertHashToUint16(vLog.Topics[1])
-					newCollection, err := utils.UtilsInterface.GetCollection(client, collectionId)
+					newCollection, err := utils.UtilsInterface.GetCollection(ctx, client, collectionId)
 					if err != nil {
 						log.Errorf("Error in getting collection with collection Id %v: %v", collectionId, err)
 						continue

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -212,7 +212,7 @@ type UtilsCmdInterface interface {
 	GetLocalMediansData(ctx context.Context, client *ethclient.Client, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue) (types.ProposeFileData, error)
 	CheckDisputeForIds(ctx context.Context, client *ethclient.Client, transactionOpts types.TransactionOptions, epoch uint32, blockIndex uint8, idsInProposedBlock []uint16, revealedCollectionIds []uint16) (*Types.Transaction, error)
 	Dispute(ctx context.Context, client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockIndex uint8, proposedBlock bindings.StructsBlock, leafId uint16, sortedValues []*big.Int) error
-	GetCollectionIdPositionInBlock(client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int
+	GetCollectionIdPositionInBlock(ctx context.Context, client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int
 	HandleDispute(ctx context.Context, client *ethclient.Client, config types.Configurations, account types.Account, epoch uint32, blockNumber *big.Int, rogueData types.Rogue, backupNodeActionsToIgnore []string) error
 	ExecuteExtendLock(flagSet *pflag.FlagSet)
 	ResetUnstakeLock(client *ethclient.Client, config types.Configurations, extendLockInput types.ExtendLockInput) (common.Hash, error)

--- a/cmd/jobList.go
+++ b/cmd/jobList.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"context"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -44,7 +45,7 @@ func (*UtilsStruct) ExecuteJobList(flagSet *pflag.FlagSet) {
 
 //This function provides the list of all jobs
 func (*UtilsStruct) GetJobList(client *ethclient.Client) error {
-	jobs, err := razorUtils.GetJobs(client)
+	jobs, err := razorUtils.GetJobs(context.Background(), client)
 	log.Debugf("JobList: Jobs: %+v", jobs)
 	if err != nil {
 		return err

--- a/cmd/jobList_test.go
+++ b/cmd/jobList_test.go
@@ -66,7 +66,7 @@ func TestGetJobList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetJobs", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.jobList, tt.args.jobListErr)
+			utilsMock.On("GetJobs", mock.Anything, mock.Anything).Return(tt.args.jobList, tt.args.jobListErr)
 			utils := &UtilsStruct{}
 
 			err := utils.GetJobList(tt.args.client)

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -679,13 +679,13 @@ func (_m *UtilsCmdInterface) GetBufferPercent() (int32, error) {
 	return r0, r1
 }
 
-// GetCollectionIdPositionInBlock provides a mock function with given fields: client, leafId, proposedBlock
-func (_m *UtilsCmdInterface) GetCollectionIdPositionInBlock(client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int {
-	ret := _m.Called(client, leafId, proposedBlock)
+// GetCollectionIdPositionInBlock provides a mock function with given fields: ctx, client, leafId, proposedBlock
+func (_m *UtilsCmdInterface) GetCollectionIdPositionInBlock(ctx context.Context, client *ethclient.Client, leafId uint16, proposedBlock bindings.StructsBlock) *big.Int {
+	ret := _m.Called(ctx, client, leafId, proposedBlock)
 
 	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16, bindings.StructsBlock) *big.Int); ok {
-		r0 = rf(client, leafId, proposedBlock)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16, bindings.StructsBlock) *big.Int); ok {
+		r0 = rf(ctx, client, leafId, proposedBlock)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -406,7 +406,7 @@ func (*UtilsStruct) MakeBlock(ctx context.Context, client *ethclient.Client, blo
 	}
 	log.Debugf("MakeBlock: Revealed data map: %+v", revealedDataMaps)
 
-	activeCollections, err := razorUtils.GetActiveCollectionIds(client)
+	activeCollections, err := razorUtils.GetActiveCollectionIds(ctx, client)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -1536,7 +1536,7 @@ func BenchmarkMakeBlock(b *testing.B) {
 					VoteWeights:          map[string]*big.Int{(big.NewInt(1).Mul(big.NewInt(697718000), big.NewInt(1e18))).String(): big.NewInt(100)},
 					InfluenceSum:         map[uint16]*big.Int{0: big.NewInt(100)},
 				}, nil)
-				utilsMock.On("GetActiveCollectionIds", mock.Anything).Return([]uint16{1}, nil)
+				utilsMock.On("GetActiveCollectionIds", mock.Anything, mock.Anything).Return([]uint16{1}, nil)
 				ut := &UtilsStruct{}
 				_, _, _, err := ut.MakeBlock(context.Background(), client, blockNumber, epoch, types.Rogue{IsRogue: false})
 				if err != nil {

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -1043,7 +1043,7 @@ func TestMakeBlock(t *testing.T) {
 			SetUpMockInterfaces()
 
 			cmdUtilsMock.On("GetSortedRevealedValues", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.revealedDataMaps, tt.args.revealedDataMapsErr)
-			utilsMock.On("GetActiveCollectionIds", mock.Anything).Return(tt.args.activeCollections, tt.args.activeCollectionsErr)
+			utilsMock.On("GetActiveCollectionIds", mock.Anything, mock.Anything).Return(tt.args.activeCollections, tt.args.activeCollectionsErr)
 			utilsMock.On("GetRogueRandomValue", mock.Anything).Return(randomValue)
 			ut := &UtilsStruct{}
 			got, got1, got2, err := ut.MakeBlock(context.Background(), client, blockNumber, epoch, tt.args.rogueData)

--- a/utils/asset.go
+++ b/utils/asset.go
@@ -29,22 +29,22 @@ func (*UtilsStruct) GetCollectionManagerWithOpts(client *ethclient.Client) (*bin
 	return UtilsInterface.GetCollectionManager(client), UtilsInterface.GetOptions()
 }
 
-func (*UtilsStruct) GetNumCollections(client *ethclient.Client) (uint16, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "GetNumCollections", client)
+func (*UtilsStruct) GetNumCollections(ctx context.Context, client *ethclient.Client) (uint16, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "GetNumCollections", client)
 	if err != nil {
 		return 0, err
 	}
 	return returnedValues[0].Interface().(uint16), nil
 }
 
-func (*UtilsStruct) GetJobs(client *ethclient.Client) ([]bindings.StructsJob, error) {
+func (*UtilsStruct) GetJobs(ctx context.Context, client *ethclient.Client) ([]bindings.StructsJob, error) {
 	var jobs []bindings.StructsJob
 	numJobs, err := AssetManagerInterface.GetNumJobs(client)
 	if err != nil {
 		return nil, err
 	}
 	for i := 1; i <= int(numJobs); i++ {
-		job, err := UtilsInterface.GetActiveJob(client, uint16(i))
+		job, err := UtilsInterface.GetActiveJob(ctx, client, uint16(i))
 		if err != nil {
 			return nil, err
 		}
@@ -53,17 +53,17 @@ func (*UtilsStruct) GetJobs(client *ethclient.Client) ([]bindings.StructsJob, er
 	return jobs, nil
 }
 
-func (*UtilsStruct) GetNumActiveCollections(client *ethclient.Client) (uint16, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "GetNumActiveCollections", client)
+func (*UtilsStruct) GetNumActiveCollections(ctx context.Context, client *ethclient.Client) (uint16, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "GetNumActiveCollections", client)
 	if err != nil {
 		return 0, err
 	}
 	return returnedValues[0].Interface().(uint16), nil
 }
 
-func (*UtilsStruct) GetAllCollections(client *ethclient.Client) ([]bindings.StructsCollection, error) {
+func (*UtilsStruct) GetAllCollections(ctx context.Context, client *ethclient.Client) ([]bindings.StructsCollection, error) {
 	var collections []bindings.StructsCollection
-	numCollections, err := UtilsInterface.GetNumCollections(client)
+	numCollections, err := UtilsInterface.GetNumCollections(ctx, client)
 	if err != nil {
 		return nil, err
 	}
@@ -77,16 +77,16 @@ func (*UtilsStruct) GetAllCollections(client *ethclient.Client) ([]bindings.Stru
 	return collections, nil
 }
 
-func (*UtilsStruct) GetCollection(client *ethclient.Client, collectionId uint16) (bindings.StructsCollection, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "GetCollection", client, collectionId)
+func (*UtilsStruct) GetCollection(ctx context.Context, client *ethclient.Client, collectionId uint16) (bindings.StructsCollection, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "GetCollection", client, collectionId)
 	if err != nil {
 		return bindings.StructsCollection{}, err
 	}
 	return returnedValues[0].Interface().(bindings.StructsCollection), nil
 }
 
-func (*UtilsStruct) GetActiveCollectionIds(client *ethclient.Client) ([]uint16, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "GetActiveCollections", client)
+func (*UtilsStruct) GetActiveCollectionIds(ctx context.Context, client *ethclient.Client) ([]uint16, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "GetActiveCollections", client)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +174,8 @@ func (*UtilsStruct) Aggregate(ctx context.Context, client *ethclient.Client, pre
 	return performAggregation(dataToCommit, weight, collection.AggregationMethod)
 }
 
-func (*UtilsStruct) GetActiveJob(client *ethclient.Client, jobId uint16) (bindings.StructsJob, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "Jobs", client, jobId)
+func (*UtilsStruct) GetActiveJob(ctx context.Context, client *ethclient.Client, jobId uint16) (bindings.StructsJob, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "Jobs", client, jobId)
 	if err != nil {
 		return bindings.StructsJob{}, err
 	}
@@ -315,24 +315,24 @@ func (*UtilsStruct) GetAssignedCollections(ctx context.Context, client *ethclien
 	return assignedCollections, seqAllottedCollections, nil
 }
 
-func (*UtilsStruct) GetLeafIdOfACollection(client *ethclient.Client, collectionId uint16) (uint16, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "GetLeafIdOfACollection", client, collectionId)
+func (*UtilsStruct) GetLeafIdOfACollection(ctx context.Context, client *ethclient.Client, collectionId uint16) (uint16, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "GetLeafIdOfACollection", client, collectionId)
 	if err != nil {
 		return 0, err
 	}
 	return returnedValues[0].Interface().(uint16), nil
 }
 
-func (*UtilsStruct) GetCollectionIdFromIndex(client *ethclient.Client, medianIndex uint16) (uint16, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "GetCollectionIdFromIndex", client, medianIndex)
+func (*UtilsStruct) GetCollectionIdFromIndex(ctx context.Context, client *ethclient.Client, medianIndex uint16) (uint16, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "GetCollectionIdFromIndex", client, medianIndex)
 	if err != nil {
 		return 0, err
 	}
 	return returnedValues[0].Interface().(uint16), nil
 }
 
-func (*UtilsStruct) GetCollectionIdFromLeafId(client *ethclient.Client, leafId uint16) (uint16, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(AssetManagerInterface, "GetCollectionIdFromLeafId", client, leafId)
+func (*UtilsStruct) GetCollectionIdFromLeafId(ctx context.Context, client *ethclient.Client, leafId uint16) (uint16, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, AssetManagerInterface, "GetCollectionIdFromLeafId", client, leafId)
 	if err != nil {
 		return 0, err
 	}
@@ -437,7 +437,7 @@ func (*UtilsStruct) HandleOfficialJobsFromJSONFile(client *ethclient.Client, col
 }
 
 // InitJobsCache initializes the jobs cache with data fetched from the blockchain
-func InitJobsCache(client *ethclient.Client, jobsCache *cache.JobsCache) error {
+func InitJobsCache(ctx context.Context, client *ethclient.Client, jobsCache *cache.JobsCache) error {
 	jobsCache.Mu.Lock()
 	defer jobsCache.Mu.Unlock()
 
@@ -451,7 +451,7 @@ func InitJobsCache(client *ethclient.Client, jobsCache *cache.JobsCache) error {
 		return err
 	}
 	for i := 1; i <= int(numJobs); i++ {
-		job, err := UtilsInterface.GetActiveJob(client, uint16(i))
+		job, err := UtilsInterface.GetActiveJob(ctx, client, uint16(i))
 		if err != nil {
 			return err
 		}

--- a/utils/asset_test.go
+++ b/utils/asset_test.go
@@ -268,7 +268,7 @@ func TestGetActiveCollectionIds(t *testing.T) {
 			assetManagerMock.On("GetActiveCollections", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.activeAssetIds, tt.args.activeAssetIdsErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetActiveCollectionIds(client)
+			got, err := utils.GetActiveCollectionIds(context.Background(), client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetActiveCollections() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -401,7 +401,7 @@ func TestGetActiveJob(t *testing.T) {
 			assetManagerMock.On("Jobs", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("uint16")).Return(tt.args.job, tt.args.jobErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetActiveJob(client, jobId)
+			got, err := utils.GetActiveJob(context.Background(), client, jobId)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetActiveJob() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -462,7 +462,7 @@ func TestGetCollection(t *testing.T) {
 			assetManagerMock.On("GetCollection", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("uint16")).Return(tt.args.asset, tt.args.assetErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetCollection(client, collectionId)
+			got, err := utils.GetCollection(context.Background(), client, collectionId)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetCollection() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -544,10 +544,10 @@ func TestGetAllCollections(t *testing.T) {
 			}
 			utils := StartRazor(optionsPackageStruct)
 
-			utilsMock.On("GetNumCollections", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.numAssets, tt.args.numAssetsErr)
+			utilsMock.On("GetNumCollections", mock.Anything, mock.Anything).Return(tt.args.numAssets, tt.args.numAssetsErr)
 			assetMock.On("GetCollection", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("uint16")).Return(tt.args.collection, tt.args.collectionErr)
 
-			got, err := utils.GetAllCollections(client)
+			got, err := utils.GetAllCollections(context.Background(), client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAllCollections() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -869,9 +869,9 @@ func TestGetJobs(t *testing.T) {
 			utils := StartRazor(optionsPackageStruct)
 
 			assetMock.On("GetNumJobs", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.numJobs, tt.args.numJobsErr)
-			utilsMock.On("GetActiveJob", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("uint16")).Return(tt.args.activeJob, tt.args.activeJobErr)
+			utilsMock.On("GetActiveJob", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.activeJob, tt.args.activeJobErr)
 
-			got, err := utils.GetJobs(client)
+			got, err := utils.GetJobs(context.Background(), client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetJobs() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -931,7 +931,7 @@ func TestGetNumActiveCollections(t *testing.T) {
 			assetManagerMock.On("GetNumActiveCollections", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.numOfActiveAssets, tt.args.numOfActiveAssetsErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetNumActiveCollections(client)
+			got, err := utils.GetNumActiveCollections(context.Background(), client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetNumActiveCollections() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -988,10 +988,10 @@ func TestGetNumCollections(t *testing.T) {
 			utils := StartRazor(optionsPackageStruct)
 
 			utilsMock.On("GetOptions").Return(callOpts)
-			assetManagerMock.On("GetNumCollections", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.numOfAssets, tt.args.numOfAssetsErr)
+			assetManagerMock.On("GetNumCollections", mock.Anything, mock.Anything).Return(tt.args.numOfAssets, tt.args.numOfAssetsErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetNumCollections(client)
+			got, err := utils.GetNumCollections(context.Background(), client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetNumCollections() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1452,7 +1452,7 @@ func TestGetLeafIdOfACollection(t *testing.T) {
 			assetManagerMock.On("GetLeafIdOfACollection", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.leafId, tt.args.leafIdErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetLeafIdOfACollection(client, collectionId)
+			got, err := utils.GetLeafIdOfACollection(context.Background(), client, collectionId)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetLeafIdOfACollection() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1509,7 +1509,7 @@ func TestGetCollectionIdFromIndex(t *testing.T) {
 			assetManagerMock.On("GetCollectionIdFromIndex", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.collectionId, tt.args.collectionIdErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetCollectionIdFromIndex(client, medianIndex)
+			got, err := utils.GetCollectionIdFromIndex(context.Background(), client, medianIndex)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetCollectionIdFromIndex() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1563,10 +1563,10 @@ func TestGetCollectionIdFromLeafId(t *testing.T) {
 				AssetManagerInterface: assetManagerMock,
 			}
 			utils := StartRazor(optionsPackageStruct)
-			assetManagerMock.On("GetCollectionIdFromLeafId", mock.AnythingOfType("*ethclient.Client"), mock.Anything).Return(tt.args.collectionId, tt.args.collectionIdErr)
+			assetManagerMock.On("GetCollectionIdFromLeafId", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.collectionId, tt.args.collectionIdErr)
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
-			got, err := utils.GetCollectionIdFromLeafId(client, leafId)
+			got, err := utils.GetCollectionIdFromLeafId(context.Background(), client, leafId)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetCollectionIdFromLeafId() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/utils/client_methods.go
+++ b/utils/client_methods.go
@@ -26,16 +26,16 @@ func (*ClientStruct) GetLatestBlockWithRetry(ctx context.Context, client *ethcli
 	return returnedValues[0].Interface().(*types.Header), nil
 }
 
-func (*ClientStruct) SuggestGasPriceWithRetry(client *ethclient.Client) (*big.Int, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(ClientInterface, "SuggestGasPrice", client, context.Background())
+func (*ClientStruct) SuggestGasPriceWithRetry(ctx context.Context, client *ethclient.Client) (*big.Int, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, ClientInterface, "SuggestGasPrice", client, context.Background())
 	if err != nil {
 		return nil, err
 	}
 	return returnedValues[0].Interface().(*big.Int), nil
 }
 
-func (*ClientStruct) EstimateGasWithRetry(client *ethclient.Client, message ethereum.CallMsg) (uint64, error) {
-	returnedValues, err := InvokeFunctionWithRetryAttempts(ClientInterface, "EstimateGas", client, context.Background(), message)
+func (*ClientStruct) EstimateGasWithRetry(ctx context.Context, client *ethclient.Client, message ethereum.CallMsg) (uint64, error) {
+	returnedValues, err := InvokeFunctionWithRetryAttempts(ctx, ClientInterface, "EstimateGas", client, context.Background(), message)
 	if err != nil {
 		return 0, err
 	}

--- a/utils/client_methods_test.go
+++ b/utils/client_methods_test.go
@@ -62,7 +62,7 @@ func TestOptionUtilsStruct_SuggestGasPriceWithRetry(t *testing.T) {
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
 			clientUtils := ClientStruct{}
-			got, err := clientUtils.SuggestGasPriceWithRetry(client)
+			got, err := clientUtils.SuggestGasPriceWithRetry(context.Background(), client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SuggestGasPriceWithRetry() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -178,7 +178,7 @@ func TestUtilsStruct_EstimateGasWithRetry(t *testing.T) {
 			retryMock.On("RetryAttempts", mock.AnythingOfType("uint")).Return(retry.Attempts(1))
 
 			clientUtils := ClientStruct{}
-			got, err := clientUtils.EstimateGasWithRetry(client, message)
+			got, err := clientUtils.EstimateGasWithRetry(context.Background(), client, message)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EstimateGasWithRetry() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/utils/common.go
+++ b/utils/common.go
@@ -35,7 +35,7 @@ func (*UtilsStruct) FetchBalance(client *ethclient.Client, accountAddress string
 
 	returnedValues, err := InvokeFunctionWithRetryAttempts(CoinInterface, "BalanceOf", erc20Contract, &opts, address)
 	if err != nil {
-		return nil, err
+		return big.NewInt(0), err
 	}
 	return returnedValues[0].Interface().(*big.Int), nil
 }

--- a/utils/common.go
+++ b/utils/common.go
@@ -35,7 +35,7 @@ func (*UtilsStruct) FetchBalance(client *ethclient.Client, accountAddress string
 
 	returnedValues, err := InvokeFunctionWithRetryAttempts(CoinInterface, "BalanceOf", erc20Contract, &opts, address)
 	if err != nil {
-		return big.NewInt(0), err
+		return nil, err
 	}
 	return returnedValues[0].Interface().(*big.Int), nil
 }

--- a/utils/common.go
+++ b/utils/common.go
@@ -33,7 +33,7 @@ func (*UtilsStruct) FetchBalance(client *ethclient.Client, accountAddress string
 	erc20Contract := UtilsInterface.GetTokenManager(client)
 	opts := UtilsInterface.GetOptions()
 
-	returnedValues, err := InvokeFunctionWithRetryAttempts(CoinInterface, "BalanceOf", erc20Contract, &opts, address)
+	returnedValues, err := InvokeFunctionWithRetryAttempts(context.Background(), CoinInterface, "BalanceOf", erc20Contract, &opts, address)
 	if err != nil {
 		return big.NewInt(0), err
 	}

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -107,22 +107,22 @@ type Utils interface {
 	GetVoteManager(client *ethclient.Client) *bindings.VoteManager
 	GetCollectionManager(client *ethclient.Client) *bindings.CollectionManager
 	GetCollectionManagerWithOpts(client *ethclient.Client) (*bindings.CollectionManager, bind.CallOpts)
-	GetNumCollections(client *ethclient.Client) (uint16, error)
-	GetActiveJob(client *ethclient.Client, jobId uint16) (bindings.StructsJob, error)
-	GetCollection(client *ethclient.Client, collectionId uint16) (bindings.StructsCollection, error)
+	GetNumCollections(ctx context.Context, client *ethclient.Client) (uint16, error)
+	GetActiveJob(ctx context.Context, client *ethclient.Client, jobId uint16) (bindings.StructsJob, error)
+	GetCollection(ctx context.Context, client *ethclient.Client, collectionId uint16) (bindings.StructsCollection, error)
 	GetActiveCollection(collectionsCache *cache.CollectionsCache, collectionId uint16) (bindings.StructsCollection, error)
 	Aggregate(ctx context.Context, client *ethclient.Client, previousEpoch uint32, collection bindings.StructsCollection, commitParams *types.CommitParams) (*big.Int, error)
 	GetDataToCommitFromJobs(jobs []bindings.StructsJob, commitParams *types.CommitParams) ([]*big.Int, []uint8)
 	GetDataToCommitFromJob(job bindings.StructsJob, commitParams *types.CommitParams) (*big.Int, error)
 	GetAssignedCollections(ctx context.Context, client *ethclient.Client, numActiveCollections uint16, seed []byte) (map[int]bool, []*big.Int, error)
-	GetLeafIdOfACollection(client *ethclient.Client, collectionId uint16) (uint16, error)
-	GetCollectionIdFromIndex(client *ethclient.Client, medianIndex uint16) (uint16, error)
-	GetCollectionIdFromLeafId(client *ethclient.Client, leafId uint16) (uint16, error)
-	GetNumActiveCollections(client *ethclient.Client) (uint16, error)
+	GetLeafIdOfACollection(ctx context.Context, client *ethclient.Client, collectionId uint16) (uint16, error)
+	GetCollectionIdFromIndex(ctx context.Context, client *ethclient.Client, medianIndex uint16) (uint16, error)
+	GetCollectionIdFromLeafId(ctx context.Context, client *ethclient.Client, leafId uint16) (uint16, error)
+	GetNumActiveCollections(ctx context.Context, client *ethclient.Client) (uint16, error)
 	GetAggregatedDataOfCollection(ctx context.Context, client *ethclient.Client, collectionId uint16, epoch uint32, commitParams *types.CommitParams) (*big.Int, error)
-	GetJobs(client *ethclient.Client) ([]bindings.StructsJob, error)
-	GetAllCollections(client *ethclient.Client) ([]bindings.StructsCollection, error)
-	GetActiveCollectionIds(client *ethclient.Client) ([]uint16, error)
+	GetJobs(ctx context.Context, client *ethclient.Client) ([]bindings.StructsJob, error)
+	GetAllCollections(ctx context.Context, client *ethclient.Client) ([]bindings.StructsCollection, error)
+	GetActiveCollectionIds(ctx context.Context, client *ethclient.Client) ([]uint16, error)
 	HandleOfficialJobsFromJSONFile(client *ethclient.Client, collection bindings.StructsCollection, dataString string, commitParams *types.CommitParams) ([]bindings.StructsJob, []uint16)
 	ConnectToClient(provider string) *ethclient.Client
 	FetchBalance(client *ethclient.Client, accountAddress string) (*big.Int, error)
@@ -172,8 +172,8 @@ type ClientUtils interface {
 	SuggestGasPrice(client *ethclient.Client, ctx context.Context) (*big.Int, error)
 	EstimateGas(client *ethclient.Client, ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	FilterLogs(client *ethclient.Client, ctx context.Context, q ethereum.FilterQuery) ([]Types.Log, error)
-	SuggestGasPriceWithRetry(client *ethclient.Client) (*big.Int, error)
-	EstimateGasWithRetry(client *ethclient.Client, message ethereum.CallMsg) (uint64, error)
+	SuggestGasPriceWithRetry(ctx context.Context, client *ethclient.Client) (*big.Int, error)
+	EstimateGasWithRetry(ctx context.Context, client *ethclient.Client, message ethereum.CallMsg) (uint64, error)
 	GetLatestBlockWithRetry(ctx context.Context, client *ethclient.Client) (*Types.Header, error)
 	FilterLogsWithRetry(ctx context.Context, client *ethclient.Client, query ethereum.FilterQuery) ([]Types.Log, error)
 	BalanceAtWithRetry(ctx context.Context, client *ethclient.Client, account common.Address) (*big.Int, error)
@@ -306,7 +306,7 @@ type FileUtils interface {
 }
 
 type GasUtils interface {
-	GetGasPrice(client *ethclient.Client, config types.Configurations) *big.Int
+	GetGasPrice(ctx context.Context, client *ethclient.Client, config types.Configurations) *big.Int
 	GetGasLimit(ctx context.Context, transactionData types.TransactionOptions, txnOpts *bind.TransactOpts) (uint64, error)
 	IncreaseGasLimitValue(ctx context.Context, client *ethclient.Client, gasLimit uint64, gasLimitMultiplier float32) (uint64, error)
 }

--- a/utils/mocks/client_utils.go
+++ b/utils/mocks/client_utils.go
@@ -155,23 +155,23 @@ func (_m *ClientUtils) EstimateGas(client *ethclient.Client, ctx context.Context
 	return r0, r1
 }
 
-// EstimateGasWithRetry provides a mock function with given fields: client, message
-func (_m *ClientUtils) EstimateGasWithRetry(client *ethclient.Client, message ethereum.CallMsg) (uint64, error) {
-	ret := _m.Called(client, message)
+// EstimateGasWithRetry provides a mock function with given fields: ctx, client, message
+func (_m *ClientUtils) EstimateGasWithRetry(ctx context.Context, client *ethclient.Client, message ethereum.CallMsg) (uint64, error) {
+	ret := _m.Called(ctx, client, message)
 
 	var r0 uint64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, ethereum.CallMsg) (uint64, error)); ok {
-		return rf(client, message)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, ethereum.CallMsg) (uint64, error)); ok {
+		return rf(ctx, client, message)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, ethereum.CallMsg) uint64); ok {
-		r0 = rf(client, message)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, ethereum.CallMsg) uint64); ok {
+		r0 = rf(ctx, client, message)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, ethereum.CallMsg) error); ok {
-		r1 = rf(client, message)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client, ethereum.CallMsg) error); ok {
+		r1 = rf(ctx, client, message)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -371,25 +371,25 @@ func (_m *ClientUtils) SuggestGasPrice(client *ethclient.Client, ctx context.Con
 	return r0, r1
 }
 
-// SuggestGasPriceWithRetry provides a mock function with given fields: client
-func (_m *ClientUtils) SuggestGasPriceWithRetry(client *ethclient.Client) (*big.Int, error) {
-	ret := _m.Called(client)
+// SuggestGasPriceWithRetry provides a mock function with given fields: ctx, client
+func (_m *ClientUtils) SuggestGasPriceWithRetry(ctx context.Context, client *ethclient.Client) (*big.Int, error) {
+	ret := _m.Called(ctx, client)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) (*big.Int, error)); ok {
-		return rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) (*big.Int, error)); ok {
+		return rf(ctx, client)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) *big.Int); ok {
-		r0 = rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) *big.Int); ok {
+		r0 = rf(ctx, client)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client) error); ok {
-		r1 = rf(client)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client) error); ok {
+		r1 = rf(ctx, client)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/utils/mocks/gas_utils.go
+++ b/utils/mocks/gas_utils.go
@@ -44,13 +44,13 @@ func (_m *GasUtils) GetGasLimit(ctx context.Context, transactionData types.Trans
 	return r0, r1
 }
 
-// GetGasPrice provides a mock function with given fields: client, config
-func (_m *GasUtils) GetGasPrice(client *ethclient.Client, config types.Configurations) *big.Int {
-	ret := _m.Called(client, config)
+// GetGasPrice provides a mock function with given fields: ctx, client, config
+func (_m *GasUtils) GetGasPrice(ctx context.Context, client *ethclient.Client, config types.Configurations) *big.Int {
+	ret := _m.Called(ctx, client, config)
 
 	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, types.Configurations) *big.Int); ok {
-		r0 = rf(client, config)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, types.Configurations) *big.Int); ok {
+		r0 = rf(ctx, client, config)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -345,25 +345,25 @@ func (_m *Utils) GetActiveCollection(collectionsCache *cache.CollectionsCache, c
 	return r0, r1
 }
 
-// GetActiveCollectionIds provides a mock function with given fields: client
-func (_m *Utils) GetActiveCollectionIds(client *ethclient.Client) ([]uint16, error) {
-	ret := _m.Called(client)
+// GetActiveCollectionIds provides a mock function with given fields: ctx, client
+func (_m *Utils) GetActiveCollectionIds(ctx context.Context, client *ethclient.Client) ([]uint16, error) {
+	ret := _m.Called(ctx, client)
 
 	var r0 []uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) ([]uint16, error)); ok {
-		return rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) ([]uint16, error)); ok {
+		return rf(ctx, client)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) []uint16); ok {
-		r0 = rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) []uint16); ok {
+		r0 = rf(ctx, client)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]uint16)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client) error); ok {
-		r1 = rf(client)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client) error); ok {
+		r1 = rf(ctx, client)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -371,23 +371,23 @@ func (_m *Utils) GetActiveCollectionIds(client *ethclient.Client) ([]uint16, err
 	return r0, r1
 }
 
-// GetActiveJob provides a mock function with given fields: client, jobId
-func (_m *Utils) GetActiveJob(client *ethclient.Client, jobId uint16) (bindings.StructsJob, error) {
-	ret := _m.Called(client, jobId)
+// GetActiveJob provides a mock function with given fields: ctx, client, jobId
+func (_m *Utils) GetActiveJob(ctx context.Context, client *ethclient.Client, jobId uint16) (bindings.StructsJob, error) {
+	ret := _m.Called(ctx, client, jobId)
 
 	var r0 bindings.StructsJob
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) (bindings.StructsJob, error)); ok {
-		return rf(client, jobId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) (bindings.StructsJob, error)); ok {
+		return rf(ctx, client, jobId)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) bindings.StructsJob); ok {
-		r0 = rf(client, jobId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) bindings.StructsJob); ok {
+		r0 = rf(ctx, client, jobId)
 	} else {
 		r0 = ret.Get(0).(bindings.StructsJob)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, uint16) error); ok {
-		r1 = rf(client, jobId)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client, uint16) error); ok {
+		r1 = rf(ctx, client, jobId)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -421,25 +421,25 @@ func (_m *Utils) GetAggregatedDataOfCollection(ctx context.Context, client *ethc
 	return r0, r1
 }
 
-// GetAllCollections provides a mock function with given fields: client
-func (_m *Utils) GetAllCollections(client *ethclient.Client) ([]bindings.StructsCollection, error) {
-	ret := _m.Called(client)
+// GetAllCollections provides a mock function with given fields: ctx, client
+func (_m *Utils) GetAllCollections(ctx context.Context, client *ethclient.Client) ([]bindings.StructsCollection, error) {
+	ret := _m.Called(ctx, client)
 
 	var r0 []bindings.StructsCollection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) ([]bindings.StructsCollection, error)); ok {
-		return rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) ([]bindings.StructsCollection, error)); ok {
+		return rf(ctx, client)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) []bindings.StructsCollection); ok {
-		r0 = rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) []bindings.StructsCollection); ok {
+		r0 = rf(ctx, client)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]bindings.StructsCollection)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client) error); ok {
-		r1 = rf(client)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client) error); ok {
+		r1 = rf(ctx, client)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -596,23 +596,23 @@ func (_m *Utils) GetBufferedState(header *coretypes.Header, stateBuffer uint64, 
 	return r0, r1
 }
 
-// GetCollection provides a mock function with given fields: client, collectionId
-func (_m *Utils) GetCollection(client *ethclient.Client, collectionId uint16) (bindings.StructsCollection, error) {
-	ret := _m.Called(client, collectionId)
+// GetCollection provides a mock function with given fields: ctx, client, collectionId
+func (_m *Utils) GetCollection(ctx context.Context, client *ethclient.Client, collectionId uint16) (bindings.StructsCollection, error) {
+	ret := _m.Called(ctx, client, collectionId)
 
 	var r0 bindings.StructsCollection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) (bindings.StructsCollection, error)); ok {
-		return rf(client, collectionId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) (bindings.StructsCollection, error)); ok {
+		return rf(ctx, client, collectionId)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) bindings.StructsCollection); ok {
-		r0 = rf(client, collectionId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) bindings.StructsCollection); ok {
+		r0 = rf(ctx, client, collectionId)
 	} else {
 		r0 = ret.Get(0).(bindings.StructsCollection)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, uint16) error); ok {
-		r1 = rf(client, collectionId)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client, uint16) error); ok {
+		r1 = rf(ctx, client, collectionId)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -620,23 +620,23 @@ func (_m *Utils) GetCollection(client *ethclient.Client, collectionId uint16) (b
 	return r0, r1
 }
 
-// GetCollectionIdFromIndex provides a mock function with given fields: client, medianIndex
-func (_m *Utils) GetCollectionIdFromIndex(client *ethclient.Client, medianIndex uint16) (uint16, error) {
-	ret := _m.Called(client, medianIndex)
+// GetCollectionIdFromIndex provides a mock function with given fields: ctx, client, medianIndex
+func (_m *Utils) GetCollectionIdFromIndex(ctx context.Context, client *ethclient.Client, medianIndex uint16) (uint16, error) {
+	ret := _m.Called(ctx, client, medianIndex)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) (uint16, error)); ok {
-		return rf(client, medianIndex)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) (uint16, error)); ok {
+		return rf(ctx, client, medianIndex)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) uint16); ok {
-		r0 = rf(client, medianIndex)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) uint16); ok {
+		r0 = rf(ctx, client, medianIndex)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, uint16) error); ok {
-		r1 = rf(client, medianIndex)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client, uint16) error); ok {
+		r1 = rf(ctx, client, medianIndex)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -644,23 +644,23 @@ func (_m *Utils) GetCollectionIdFromIndex(client *ethclient.Client, medianIndex 
 	return r0, r1
 }
 
-// GetCollectionIdFromLeafId provides a mock function with given fields: client, leafId
-func (_m *Utils) GetCollectionIdFromLeafId(client *ethclient.Client, leafId uint16) (uint16, error) {
-	ret := _m.Called(client, leafId)
+// GetCollectionIdFromLeafId provides a mock function with given fields: ctx, client, leafId
+func (_m *Utils) GetCollectionIdFromLeafId(ctx context.Context, client *ethclient.Client, leafId uint16) (uint16, error) {
+	ret := _m.Called(ctx, client, leafId)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) (uint16, error)); ok {
-		return rf(client, leafId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) (uint16, error)); ok {
+		return rf(ctx, client, leafId)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) uint16); ok {
-		r0 = rf(client, leafId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) uint16); ok {
+		r0 = rf(ctx, client, leafId)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, uint16) error); ok {
-		r1 = rf(client, leafId)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client, uint16) error); ok {
+		r1 = rf(ctx, client, leafId)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -934,25 +934,25 @@ func (_m *Utils) GetInfluenceSnapshot(ctx context.Context, client *ethclient.Cli
 	return r0, r1
 }
 
-// GetJobs provides a mock function with given fields: client
-func (_m *Utils) GetJobs(client *ethclient.Client) ([]bindings.StructsJob, error) {
-	ret := _m.Called(client)
+// GetJobs provides a mock function with given fields: ctx, client
+func (_m *Utils) GetJobs(ctx context.Context, client *ethclient.Client) ([]bindings.StructsJob, error) {
+	ret := _m.Called(ctx, client)
 
 	var r0 []bindings.StructsJob
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) ([]bindings.StructsJob, error)); ok {
-		return rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) ([]bindings.StructsJob, error)); ok {
+		return rf(ctx, client)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) []bindings.StructsJob); ok {
-		r0 = rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) []bindings.StructsJob); ok {
+		r0 = rf(ctx, client)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]bindings.StructsJob)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client) error); ok {
-		r1 = rf(client)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client) error); ok {
+		r1 = rf(ctx, client)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -960,23 +960,23 @@ func (_m *Utils) GetJobs(client *ethclient.Client) ([]bindings.StructsJob, error
 	return r0, r1
 }
 
-// GetLeafIdOfACollection provides a mock function with given fields: client, collectionId
-func (_m *Utils) GetLeafIdOfACollection(client *ethclient.Client, collectionId uint16) (uint16, error) {
-	ret := _m.Called(client, collectionId)
+// GetLeafIdOfACollection provides a mock function with given fields: ctx, client, collectionId
+func (_m *Utils) GetLeafIdOfACollection(ctx context.Context, client *ethclient.Client, collectionId uint16) (uint16, error) {
+	ret := _m.Called(ctx, client, collectionId)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) (uint16, error)); ok {
-		return rf(client, collectionId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) (uint16, error)); ok {
+		return rf(ctx, client, collectionId)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client, uint16) uint16); ok {
-		r0 = rf(client, collectionId)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client, uint16) uint16); ok {
+		r0 = rf(ctx, client, collectionId)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client, uint16) error); ok {
-		r1 = rf(client, collectionId)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client, uint16) error); ok {
+		r1 = rf(ctx, client, collectionId)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1108,23 +1108,23 @@ func (_m *Utils) GetMinStakeAmount(ctx context.Context, client *ethclient.Client
 	return r0, r1
 }
 
-// GetNumActiveCollections provides a mock function with given fields: client
-func (_m *Utils) GetNumActiveCollections(client *ethclient.Client) (uint16, error) {
-	ret := _m.Called(client)
+// GetNumActiveCollections provides a mock function with given fields: ctx, client
+func (_m *Utils) GetNumActiveCollections(ctx context.Context, client *ethclient.Client) (uint16, error) {
+	ret := _m.Called(ctx, client)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) (uint16, error)); ok {
-		return rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) (uint16, error)); ok {
+		return rf(ctx, client)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint16); ok {
-		r0 = rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) uint16); ok {
+		r0 = rf(ctx, client)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client) error); ok {
-		r1 = rf(client)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client) error); ok {
+		r1 = rf(ctx, client)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1132,23 +1132,23 @@ func (_m *Utils) GetNumActiveCollections(client *ethclient.Client) (uint16, erro
 	return r0, r1
 }
 
-// GetNumCollections provides a mock function with given fields: client
-func (_m *Utils) GetNumCollections(client *ethclient.Client) (uint16, error) {
-	ret := _m.Called(client)
+// GetNumCollections provides a mock function with given fields: ctx, client
+func (_m *Utils) GetNumCollections(ctx context.Context, client *ethclient.Client) (uint16, error) {
+	ret := _m.Called(ctx, client)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) (uint16, error)); ok {
-		return rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) (uint16, error)); ok {
+		return rf(ctx, client)
 	}
-	if rf, ok := ret.Get(0).(func(*ethclient.Client) uint16); ok {
-		r0 = rf(client)
+	if rf, ok := ret.Get(0).(func(context.Context, *ethclient.Client) uint16); ok {
+		r0 = rf(ctx, client)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(*ethclient.Client) error); ok {
-		r1 = rf(client)
+	if rf, ok := ret.Get(1).(func(context.Context, *ethclient.Client) error); ok {
+		r1 = rf(ctx, client)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/utils/options.go
+++ b/utils/options.go
@@ -37,7 +37,7 @@ func (*UtilsStruct) GetTxnOpts(ctx context.Context, transactionData types.Transa
 	nonce, err := ClientInterface.GetNonceAtWithRetry(ctx, transactionData.Client, common.HexToAddress(account.Address))
 	CheckError("Error in fetching nonce: ", err)
 
-	gasPrice := GasInterface.GetGasPrice(transactionData.Client, transactionData.Config)
+	gasPrice := GasInterface.GetGasPrice(ctx, transactionData.Client, transactionData.Config)
 	txnOpts, err := BindInterface.NewKeyedTransactorWithChainID(privateKey, transactionData.ChainId)
 	CheckError("Error in getting transactor: ", err)
 	txnOpts.Nonce = big.NewInt(int64(nonce))
@@ -63,7 +63,7 @@ func (*UtilsStruct) GetTxnOpts(ctx context.Context, transactionData types.Transa
 	return txnOpts
 }
 
-func (*GasStruct) GetGasPrice(client *ethclient.Client, config types.Configurations) *big.Int {
+func (*GasStruct) GetGasPrice(ctx context.Context, client *ethclient.Client, config types.Configurations) *big.Int {
 	var gas *big.Int
 	if config.GasPrice != 0 {
 		gas = big.NewInt(1).Mul(big.NewInt(int64(config.GasPrice)), big.NewInt(1e9))
@@ -71,7 +71,7 @@ func (*GasStruct) GetGasPrice(client *ethclient.Client, config types.Configurati
 		gas = big.NewInt(0)
 	}
 	var err error
-	suggestedGasPrice, err := ClientInterface.SuggestGasPriceWithRetry(client)
+	suggestedGasPrice, err := ClientInterface.SuggestGasPriceWithRetry(ctx, client)
 	if err != nil {
 		log.Error(err)
 		return UtilsInterface.MultiplyFloatAndBigInt(gas, float64(config.GasMultiplier))
@@ -117,7 +117,7 @@ func (*GasStruct) GetGasLimit(ctx context.Context, transactionData types.Transac
 		}
 		log.Debug("Calculated gas limit for reveal: ", gasLimit)
 	} else {
-		gasLimit, err = ClientInterface.EstimateGasWithRetry(transactionData.Client, msg)
+		gasLimit, err = ClientInterface.EstimateGasWithRetry(ctx, transactionData.Client, msg)
 		if err != nil {
 			log.Error("GetGasLimit: Error in getting gasLimit: ", err)
 			//If estimateGas throws an error for a transaction than gasLimit should be picked up from the config

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -112,7 +112,7 @@ func Test_getGasPrice(t *testing.T) {
 			UtilsMock := new(mocks.Utils)
 			clientUtilsMock := new(mocks.ClientUtils)
 
-			clientUtilsMock.On("SuggestGasPriceWithRetry", mock.AnythingOfType("*ethclient.Client")).Return(tt.args.suggestedGasPrice, tt.args.suggestedGasPriceErr)
+			clientUtilsMock.On("SuggestGasPriceWithRetry", mock.Anything, mock.Anything).Return(tt.args.suggestedGasPrice, tt.args.suggestedGasPriceErr)
 			UtilsMock.On("MultiplyFloatAndBigInt", mock.AnythingOfType("*big.Int"), mock.AnythingOfType("float64")).Return(tt.args.multipliedGasPrice)
 
 			fatal = false
@@ -123,7 +123,7 @@ func Test_getGasPrice(t *testing.T) {
 			}
 			StartRazor(optionsPackageStruct)
 			gasUtils := GasStruct{}
-			got := gasUtils.GetGasPrice(client, tt.args.config)
+			got := gasUtils.GetGasPrice(context.Background(), client, tt.args.config)
 			if fatal != tt.expectedFatal {
 				if got.Cmp(tt.want) != 0 {
 					t.Errorf("getGasPrice() = %v, want %v", got, tt.want)
@@ -292,10 +292,9 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 			utils := StartRazor(optionsPackageStruct)
 
 			clientMock.On("GetNonceAtWithRetry", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.nonce, tt.args.nonceErr)
-			gasMock.On("GetGasPrice", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("types.Configurations")).Return(gasPrice)
+			gasMock.On("GetGasPrice", mock.Anything, mock.Anything, mock.Anything).Return(gasPrice)
 			bindMock.On("NewKeyedTransactorWithChainID", mock.AnythingOfType("*ecdsa.PrivateKey"), mock.AnythingOfType("*big.Int")).Return(tt.args.txnOpts, tt.args.txnOptsErr)
 			gasMock.On("GetGasLimit", mock.Anything, transactionData, txnOpts).Return(tt.args.gasLimit, tt.args.gasLimitErr)
-			clientMock.On("SuggestGasPriceWithRetry", mock.AnythingOfType("*ethclient.Client")).Return(big.NewInt(1), nil)
 			utilsMock.On("MultiplyFloatAndBigInt", mock.AnythingOfType("*big.Int"), mock.AnythingOfType("float64")).Return(big.NewInt(1))
 			clientMock.On("GetLatestBlockWithRetry", mock.Anything, mock.Anything).Return(tt.args.latestHeader, tt.args.latestHeaderErr)
 
@@ -480,7 +479,7 @@ func TestUtilsStruct_GetGasLimit(t *testing.T) {
 
 			abiMock.On("Parse", reader).Return(tt.args.parsedData, tt.args.parseErr)
 			abiMock.On("Pack", parsedData, mock.AnythingOfType("string"), mock.Anything).Return(tt.args.inputData, tt.args.packErr)
-			clientUtilsMock.On("EstimateGasWithRetry", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.gasLimit, tt.args.gasLimitErr)
+			clientUtilsMock.On("EstimateGasWithRetry", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.gasLimit, tt.args.gasLimitErr)
 			gasUtilsMock.On("IncreaseGasLimitValue", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.increaseGasLimit, tt.args.increaseGasLimitErr)
 			utilsMock.On("ToAssign", mock.Anything, mock.Anything).Return(tt.args.toAssign, tt.args.toAssignErr)
 


### PR DESCRIPTION
# Description

After merging #1235 to develop, the function signature for `InvokeFunctionWithRetryAttempts` was updated with addition of context as a parameter.

So the the changes in PR #1252 wasn't rebased to the updated changes and was merged to develop without rebasing.
So it cause the build to go fail, this PR adds context as a parameter to the functions needed and will make the compilation and build successful.
 And fixes respective tests.

Fixes https://linear.app/interstellar-research/issue/RAZ-1060

This is the extended fix for issue https://linear.app/interstellar-research/issue/RAZ-1044 


# How Has This Been Tested?

Ran a node on local for few epochs and tested the changes reflected.