### PR TITLE
refactor: removed fatal logs from GetTxnOpts()

### DIFF
--- a/cmd/addStake.go
+++ b/cmd/addStake.go
@@ -105,7 +105,10 @@ func (*UtilsStruct) StakeCoins(rpcParameters rpc.RPCParameters, txnArgs types.Tr
 	txnArgs.MethodName = "stake"
 	txnArgs.Parameters = []interface{}{epoch, txnArgs.Amount}
 	txnArgs.ABI = bindings.StakeManagerMetaData.ABI
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/addStake_test.go
+++ b/cmd/addStake_test.go
@@ -25,6 +25,7 @@ func TestStakeCoins(t *testing.T) {
 		txnArgs     types.TransactionOptions
 		epoch       uint32
 		getEpochErr error
+		txnOptsErr  error
 		stakeTxn    *Types.Transaction
 		stakeErr    error
 		hash        common.Hash
@@ -80,12 +81,25 @@ func TestStakeCoins(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("stake error"),
 		},
+		{
+			name: "Test 4: When there is an error in getting transaction options",
+			args: args{
+				txnArgs: types.TransactionOptions{
+					Amount: big.NewInt(1000),
+				},
+				epoch:       2,
+				getEpochErr: nil,
+				txnOptsErr:  errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			utilsMock.On("GetEpoch", mock.Anything).Return(tt.args.epoch, tt.args.getEpochErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 			stakeManagerMock.On("Stake", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.stakeTxn, tt.args.stakeErr)
 

--- a/cmd/approve.go
+++ b/cmd/approve.go
@@ -25,7 +25,10 @@ func (*UtilsStruct) Approve(rpcParameters rpc.RPCParameters, txnArgs types.Trans
 		txnArgs.MethodName = "approve"
 		txnArgs.ABI = bindings.RAZORMetaData.ABI
 		txnArgs.Parameters = []interface{}{common.HexToAddress(core.StakeManagerAddress), txnArgs.Amount}
-		txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+		txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+		if err != nil {
+			return core.NilHash, err
+		}
 
 		client, err := rpcParameters.RPCManager.GetBestRPCClient()
 		if err != nil {

--- a/cmd/approve_test.go
+++ b/cmd/approve_test.go
@@ -19,6 +19,7 @@ func TestApprove(t *testing.T) {
 		callOpts        bind.CallOpts
 		allowanceAmount *big.Int
 		allowanceError  error
+		txnOptsErr      error
 		approveTxn      *Types.Transaction
 		approveError    error
 		hash            common.Hash
@@ -115,13 +116,26 @@ func TestApprove(t *testing.T) {
 			want:    common.Hash{0},
 			wantErr: errors.New("approve error"),
 		},
+		{
+			name: "Test 5: When there is error in getting txnOpts",
+			args: args{
+				txnArgs: types.TransactionOptions{
+					Amount: big.NewInt(10000),
+				},
+				callOpts:        bind.CallOpts{},
+				allowanceAmount: big.NewInt(0),
+				txnOptsErr:      errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
 			utilsMock.On("GetOptions").Return(tt.args.callOpts)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 			utilsMock.On("Allowance", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.allowanceAmount, tt.args.allowanceError)
 			tokenManagerMock.On("Approve", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.approveTxn, tt.args.approveError)

--- a/cmd/claimBounty.go
+++ b/cmd/claimBounty.go
@@ -163,7 +163,10 @@ func (*UtilsStruct) ClaimBounty(rpcParameters rpc.RPCParameters, config types.Co
 		return core.NilHash, nil
 	}
 
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {
 		return core.NilHash, err

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -157,6 +157,7 @@ func TestClaimBounty(t *testing.T) {
 		epochErr        error
 		bountyLock      types.BountyLock
 		bountyLockErr   error
+		txnOptsErr      error
 		redeemBountyTxn *Types.Transaction
 		redeemBountyErr error
 		hash            common.Hash
@@ -250,6 +251,19 @@ func TestClaimBounty(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: nil,
 		},
+		{
+			name: "Test 8: When there is an error in getting txnOpts",
+			args: args{
+				epoch: 70,
+				bountyLock: types.BountyLock{
+					Amount:      big.NewInt(1000),
+					RedeemAfter: 70,
+				},
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -267,7 +281,7 @@ func TestClaimBounty(t *testing.T) {
 			utilsMock.On("GetBountyLock", mock.Anything, mock.Anything).Return(tt.args.bountyLock, tt.args.bountyLockErr)
 			timeMock.On("Sleep", mock.AnythingOfType("time.Duration")).Return()
 			utilsMock.On("CalculateBlockTime", mock.AnythingOfType("*ethclient.Client")).Return(blockTime)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			stakeManagerMock.On("RedeemBounty", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("*bind.TransactOpts"), mock.AnythingOfType("uint32")).Return(tt.args.redeemBountyTxn, tt.args.redeemBountyErr)
 			utilsMock.On("SecondsToReadableTime", mock.AnythingOfType("int")).Return(tt.args.time)
 			transactionUtilsMock.On("Hash", mock.Anything).Return(tt.args.hash)

--- a/cmd/claimCommission.go
+++ b/cmd/claimCommission.go
@@ -38,7 +38,7 @@ func (*UtilsStruct) ClaimCommission(flagSet *pflag.FlagSet) {
 	log.Debugf("ClaimCommission: Staker Info: %+v", stakerInfo)
 
 	if stakerInfo.StakerReward.Cmp(big.NewInt(0)) > 0 {
-		txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+		txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 			ChainId:         core.ChainId,
 			Config:          config,
 			ContractAddress: core.StakeManagerAddress,
@@ -47,6 +47,7 @@ func (*UtilsStruct) ClaimCommission(flagSet *pflag.FlagSet) {
 			ABI:             bindings.StakeManagerMetaData.ABI,
 			Account:         account,
 		})
+		utils.CheckError("Error in getting txn options: ", err)
 
 		log.Info("Claiming commission...")
 

--- a/cmd/claimCommission_test.go
+++ b/cmd/claimCommission_test.go
@@ -206,7 +206,7 @@ func TestClaimCommission(t *testing.T) {
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)
 			utilsMock.On("AccountManagerForKeystore").Return(&accounts.AccountManager{}, nil)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, nil)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 
 			utilsMock.On("StakerInfo", mock.Anything, mock.AnythingOfType("uint32")).Return(tt.args.stakerInfo, tt.args.stakerInfoErr)

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -151,7 +151,7 @@ func (*UtilsStruct) Commit(rpcParameters rpc.RPCParameters, config types.Configu
 		return core.NilHash, err
 	}
 
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.VoteManagerAddress,
@@ -160,6 +160,9 @@ func (*UtilsStruct) Commit(rpcParameters rpc.RPCParameters, config types.Configu
 		Parameters:      []interface{}{epoch, commitmentToSend},
 		Account:         account,
 	})
+	if err != nil {
+		return core.NilHash, err
+	}
 
 	log.Info("Commitment sent...")
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -28,11 +28,12 @@ func TestCommit(t *testing.T) {
 	)
 
 	type args struct {
-		state     int64
-		stateErr  error
-		commitTxn *Types.Transaction
-		commitErr error
-		hash      common.Hash
+		state      int64
+		stateErr   error
+		txnOptsErr error
+		commitTxn  *Types.Transaction
+		commitErr  error
+		hash       common.Hash
 	}
 	tests := []struct {
 		name    string
@@ -75,13 +76,22 @@ func TestCommit(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("commit error"),
 		},
+		{
+			name: "Test 4: When there is an error in getting txnOpts",
+			args: args{
+				state:      0,
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
 			utilsMock.On("GetBufferedState", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.state, tt.args.stateErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			voteManagerMock.On("Commit", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("*bind.TransactOpts"), mock.AnythingOfType("uint32"), mock.Anything).Return(tt.args.commitTxn, tt.args.commitErr)
 			transactionMock.On("Hash", mock.AnythingOfType("*types.Transaction")).Return(tt.args.hash)
 

--- a/cmd/confirm.go
+++ b/cmd/confirm.go
@@ -46,7 +46,10 @@ func (*UtilsStruct) ClaimBlockReward(rpcParameters rpc.RPCParameters, options ty
 
 	if selectedProposedBlock.ProposerId == stakerID {
 		log.Info("Claiming block reward...")
-		txnOpts := razorUtils.GetTxnOpts(rpcParameters, options)
+		txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, options)
+		if err != nil {
+			return core.NilHash, err
+		}
 
 		client, err := rpcParameters.RPCManager.GetBestRPCClient()
 		if err != nil {

--- a/cmd/createCollection.go
+++ b/cmd/createCollection.go
@@ -76,7 +76,7 @@ func (*UtilsStruct) CreateCollection(rpcParameters rpc.RPCParameters, config typ
 		log.Error("Error in fetching state")
 		return core.NilHash, err
 	}
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.CollectionManagerAddress,
@@ -85,6 +85,9 @@ func (*UtilsStruct) CreateCollection(rpcParameters rpc.RPCParameters, config typ
 		ABI:             bindings.CollectionManagerMetaData.ABI,
 		Account:         collectionInput.Account,
 	})
+	if err != nil {
+		return core.NilHash, err
+	}
 
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/createCollection_test.go
+++ b/cmd/createCollection_test.go
@@ -23,6 +23,7 @@ func TestCreateCollection(t *testing.T) {
 	type args struct {
 		jobIdUint8                 []uint16
 		waitForAppropriateStateErr error
+		txnOptsErr                 error
 		createCollectionTxn        *Types.Transaction
 		createCollectionErr        error
 		hash                       common.Hash
@@ -65,13 +66,22 @@ func TestCreateCollection(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("createCollection error"),
 		},
+		{
+			name: "Test 4: When there is an error in getting txnOpts",
+			args: args{
+				jobIdUint8: []uint16{1, 2},
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
 			utilsMock.On("ConvertUintArrayToUint16Array", mock.Anything).Return(tt.args.jobIdUint8)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			cmdUtilsMock.On("WaitForAppropriateState", mock.Anything, mock.Anything, mock.Anything).Return(WaitForDisputeOrConfirmStateStatus, tt.args.waitForAppropriateStateErr)
 			assetManagerMock.On("CreateCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.createCollectionTxn, tt.args.createCollectionErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)

--- a/cmd/createJob.go
+++ b/cmd/createJob.go
@@ -84,7 +84,10 @@ func (*UtilsStruct) CreateJob(rpcParameters rpc.RPCParameters, config types.Conf
 		Account:         jobInput.Account,
 	}
 
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 	log.Info("Creating Job...")
 
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()

--- a/cmd/createJob_test.go
+++ b/cmd/createJob_test.go
@@ -20,6 +20,7 @@ func TestCreateJob(t *testing.T) {
 	var config types.Configurations
 
 	type args struct {
+		txnOptsErr   error
 		createJobTxn *Types.Transaction
 		createJobErr error
 		hash         common.Hash
@@ -49,12 +50,20 @@ func TestCreateJob(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("createJob error"),
 		},
+		{
+			name: "Test 3:  When there is an error in getting txnOpts",
+			args: args{
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			assetManagerMock.On("CreateJob", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("*bind.TransactOpts"), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.createJobTxn, tt.args.createJobErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 

--- a/cmd/delegate.go
+++ b/cmd/delegate.go
@@ -81,7 +81,10 @@ func (*UtilsStruct) Delegate(rpcParameters rpc.RPCParameters, txnArgs types.Tran
 	txnArgs.MethodName = "delegate"
 	txnArgs.ABI = bindings.StakeManagerMetaData.ABI
 	txnArgs.Parameters = []interface{}{stakerId, txnArgs.Amount}
-	delegationTxnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	delegationTxnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 	log.Info("Sending Delegate transaction...")
 
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()

--- a/cmd/delegate_test.go
+++ b/cmd/delegate_test.go
@@ -20,6 +20,7 @@ func TestDelegate(t *testing.T) {
 
 	type args struct {
 		amount      *big.Int
+		txnOptsErr  error
 		delegateTxn *Types.Transaction
 		delegateErr error
 		hash        common.Hash
@@ -52,12 +53,21 @@ func TestDelegate(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("delegate error"),
 		},
+		{
+			name: "Test 3: When there is an error in getting txnOpts",
+			args: args{
+				amount:     big.NewInt(1000),
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			stakeManagerMock.On("Delegate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.delegateTxn, tt.args.delegateErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 

--- a/cmd/dispute_test.go
+++ b/cmd/dispute_test.go
@@ -5,13 +5,14 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/crypto"
 	"io/fs"
 	"math/big"
 	"razor/core/types"
 	"razor/pkg/bindings"
 	"reflect"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -91,7 +92,7 @@ func TestDispute(t *testing.T) {
 			SetUpMockInterfaces()
 
 			utilsMock.On("GetBlockManager", mock.AnythingOfType("*ethclient.Client")).Return(blockManager)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(TxnOpts, nil)
 			cmdUtilsMock.On("GiveSorted", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			cmdUtilsMock.On("GetCollectionIdPositionInBlock", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.positionOfCollectionInBlock)
 			blockManagerMock.On("FinalizeDispute", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.finalizeDisputeTxn, tt.args.finalizeDisputeErr)
@@ -529,7 +530,7 @@ func TestHandleDispute(t *testing.T) {
 				RevealedDataMaps:      tt.args.revealedDataMaps,
 			}, tt.args.mediansErr)
 			utilsMock.On("GetProposedBlock", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.proposedBlock, tt.args.proposedBlockErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(txnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(txnOpts, nil)
 			blockManagerMock.On("DisputeBiggestStakeProposed", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.disputeBiggestStakeTxn, tt.args.disputeBiggestStakeErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.Hash)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
@@ -657,7 +658,7 @@ func TestGiveSorted(t *testing.T) {
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(tt.args.waitForBlockCompletionErr)
 			utilsMock.On("GetOptions").Return(callOpts)
 			utilsMock.On("Disputes", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.disputesMapping, tt.args.disputesMappingErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(txnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(txnOpts, nil)
 			blockManagerMock.On("GiveSorted", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.giveSorted, nil)
 			cmdUtilsMock.On("ResetDispute", mock.Anything, mock.Anything, mock.Anything)
 
@@ -958,7 +959,7 @@ func TestCheckDisputeForIds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(txnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(txnOpts, nil)
 			blockManagerMock.On("DisputeOnOrderOfIds", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.DisputeOnOrderOfIds, tt.args.DisputeOnOrderOfIdsErr)
 			gasUtilsMock.On("IncreaseGasLimitValue", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.incrementedGasLimit, tt.args.incrementedGasLimitErr)
 			blockManagerMock.On("DisputeCollectionIdShouldBePresent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.DisputeCollectionIdShouldBePresent, tt.args.DisputeCollectionIdShouldBePresentErr)
@@ -1193,7 +1194,7 @@ func BenchmarkHandleDispute(b *testing.B) {
 				cmdUtilsMock.On("GetBiggestStakeAndId", mock.Anything, mock.Anything).Return(big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)), uint32(2), nil)
 				cmdUtilsMock.On("GetLocalMediansData", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(proposedData, nil)
 				utilsMock.On("GetProposedBlock", mock.Anything, mock.Anything, mock.Anything).Return(proposedBlock, nil)
-				utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(txnOpts)
+				utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(txnOpts, nil)
 				blockManagerMock.On("DisputeBiggestStakeProposed", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&Types.Transaction{}, nil)
 				transactionMock.On("Hash", mock.Anything).Return(common.BigToHash(big.NewInt(1)))
 				utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)

--- a/cmd/initiateWithdraw.go
+++ b/cmd/initiateWithdraw.go
@@ -106,7 +106,10 @@ func (*UtilsStruct) HandleUnstakeLock(rpcParameters rpc.RPCParameters, account t
 		Parameters:      []interface{}{stakerId},
 		Account:         account,
 	}
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 
 	if big.NewInt(int64(epoch)).Cmp(unstakeLock.UnlockAfter) >= 0 && big.NewInt(int64(epoch)).Cmp(withdrawBefore) <= 0 {
 		log.Debug("Calling InitiateWithdraw() with arguments stakerId: ", stakerId)

--- a/cmd/modifyCollectionStatus.go
+++ b/cmd/modifyCollectionStatus.go
@@ -82,7 +82,10 @@ func (*UtilsStruct) ModifyCollectionStatus(rpcParameters rpc.RPCParameters, conf
 		Account:         modifyCollectionInput.Account,
 	}
 
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 	log.Infof("Changing active status of collection: %d from %t to %t", modifyCollectionInput.CollectionId, !modifyCollectionInput.Status, modifyCollectionInput.Status)
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/modifyCollectionStatus_test.go
+++ b/cmd/modifyCollectionStatus_test.go
@@ -24,6 +24,7 @@ func TestModifyAssetStatus(t *testing.T) {
 		currentStatusErr    error
 		epoch               uint32
 		epochErr            error
+		txnOptsErr          error
 		SetCollectionStatus *Types.Transaction
 		SetAssetStatusErr   error
 		hash                common.Hash
@@ -91,13 +92,24 @@ func TestModifyAssetStatus(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("WaitForAppropriateState error"),
 		},
+		{
+			name: "Test 6: When there is an error in getting txnOpts",
+			args: args{
+				status:              true,
+				currentStatus:       false,
+				SetCollectionStatus: &Types.Transaction{},
+				txnOptsErr:          errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
 			utilsMock.On("GetActiveStatus", mock.Anything, mock.Anything).Return(tt.args.currentStatus, tt.args.currentStatusErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			cmdUtilsMock.On("WaitForAppropriateState", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.epoch, tt.args.epochErr)
 			assetManagerMock.On("SetCollectionStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.SetCollectionStatus, tt.args.SetAssetStatusErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -140,7 +140,7 @@ func (*UtilsStruct) Propose(rpcParameters rpc.RPCParameters, config types.Config
 	log.Debugf("Propose: Iteration: %d Biggest Staker Id: %d", iteration, biggestStakerId)
 	log.Info("Proposing block...")
 
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.BlockManagerAddress,
@@ -149,6 +149,9 @@ func (*UtilsStruct) Propose(rpcParameters rpc.RPCParameters, config types.Config
 		Parameters:      []interface{}{epoch, ids, medians, big.NewInt(int64(iteration)), biggestStakerId},
 		Account:         account,
 	})
+	if err != nil {
+		return err
+	}
 
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -70,6 +70,7 @@ func TestPropose(t *testing.T) {
 		fileNameErr                error
 		saveDataErr                error
 		mediansBigInt              []*big.Int
+		txnOptsErr                 error
 		proposeTxn                 *Types.Transaction
 		proposeErr                 error
 		hash                       common.Hash
@@ -476,6 +477,26 @@ func TestPropose(t *testing.T) {
 			},
 			wantErr: errors.New("smallestStakerId error"),
 		},
+		{
+			name: "Test 19: When there is an error in getting txnOpts",
+			args: args{
+				state:                   2,
+				staker:                  bindings.StructsStaker{},
+				numStakers:              5,
+				biggestStake:            big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				biggestStakerId:         2,
+				salt:                    saltBytes32,
+				iteration:               1,
+				numOfProposedBlocks:     3,
+				sortedProposedBlockIds:  []uint32{2, 1, 0},
+				maxAltBlocks:            4,
+				lastIteration:           big.NewInt(5),
+				lastProposedBlockStruct: bindings.StructsBlock{},
+				medians:                 []*big.Int{big.NewInt(6701548), big.NewInt(478307)},
+				txnOptsErr:              errors.New("txnOpts error"),
+			},
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		SetUpMockInterfaces()
@@ -497,7 +518,7 @@ func TestPropose(t *testing.T) {
 		utilsMock.On("ConvertUint32ArrayToBigIntArray", mock.Anything).Return(tt.args.mediansBigInt)
 		pathMock.On("GetProposeDataFileName", mock.AnythingOfType("string")).Return(tt.args.fileName, tt.args.fileNameErr)
 		fileUtilsMock.On("SaveDataToProposeJsonFile", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.saveDataErr)
-		utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+		utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 		blockManagerMock.On("Propose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.proposeTxn, tt.args.proposeErr)
 		transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 

--- a/cmd/resetUnstakeLock.go
+++ b/cmd/resetUnstakeLock.go
@@ -51,7 +51,7 @@ func (*UtilsStruct) ExecuteExtendLock(flagSet *pflag.FlagSet) {
 
 //This function is used to reset the lock once the withdraw lock period is over
 func (*UtilsStruct) ResetUnstakeLock(rpcParameters rpc.RPCParameters, config types.Configurations, extendLockInput types.ExtendLockInput) (common.Hash, error) {
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.StakeManagerAddress,
@@ -60,6 +60,9 @@ func (*UtilsStruct) ResetUnstakeLock(rpcParameters rpc.RPCParameters, config typ
 		ABI:             bindings.StakeManagerMetaData.ABI,
 		Account:         extendLockInput.Account,
 	})
+	if err != nil {
+		return core.NilHash, err
+	}
 
 	log.Info("Extending lock...")
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()

--- a/cmd/resetUnstakeLock_test.go
+++ b/cmd/resetUnstakeLock_test.go
@@ -20,6 +20,7 @@ func TestExtendLock(t *testing.T) {
 	var config types.Configurations
 
 	type args struct {
+		txnOptsErr   error
 		resetLockTxn *Types.Transaction
 		resetLockErr error
 		hash         common.Hash
@@ -50,12 +51,20 @@ func TestExtendLock(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("resetLock error"),
 		},
+		{
+			name: "Test 3: When there is an error in getting txnOpts",
+			args: args{
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			stakeManagerMock.On("ResetUnstakeLock", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("*bind.TransactOpts"), mock.AnythingOfType("uint32")).Return(tt.args.resetLockTxn, tt.args.resetLockErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -64,6 +64,10 @@ func (*UtilsStruct) Reveal(rpcParameters rpc.RPCParameters, config types.Configu
 		Parameters:      []interface{}{epoch, treeRevealData, signature},
 		Account:         account,
 	})
+	if err != nil {
+		log.Error(err)
+		return core.NilHash, err
+	}
 
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/reveal.go
+++ b/cmd/reveal.go
@@ -55,7 +55,7 @@ func (*UtilsStruct) Reveal(rpcParameters rpc.RPCParameters, config types.Configu
 
 	log.Info("Revealing votes...")
 
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.VoteManagerAddress,

--- a/cmd/reveal_test.go
+++ b/cmd/reveal_test.go
@@ -99,6 +99,7 @@ func TestReveal(t *testing.T) {
 		merkleTree     [][][]byte
 		merkleTreeErr  error
 		treeRevealData bindings.StructsMerkleTree
+		txnOptsErr     error
 		revealTxn      *Types.Transaction
 		revealErr      error
 		hash           common.Hash
@@ -133,7 +134,7 @@ func TestReveal(t *testing.T) {
 			wantErr: errors.New("state error"),
 		},
 		{
-			name: "Test 6: When Reveal transaction fails",
+			name: "Test 3: When Reveal transaction fails",
 			args: args{
 				state:     1,
 				stateErr:  nil,
@@ -145,13 +146,23 @@ func TestReveal(t *testing.T) {
 			wantErr: errors.New("reveal error"),
 		},
 		{
-			name: "Test 7: When there is an error in getting merkle tree",
+			name: "Test 4: When there is an error in getting merkle tree",
 			args: args{
 				state:         1,
 				merkleTreeErr: errors.New("merkle tree error"),
 			},
 			want:    core.NilHash,
 			wantErr: errors.New("merkle tree error"),
+		},
+		{
+			name: "Test 5: When there is an error in getting txnOpts",
+			args: args{
+				state:      1,
+				stateErr:   nil,
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
 		},
 	}
 	for _, tt := range tests {
@@ -161,7 +172,7 @@ func TestReveal(t *testing.T) {
 			utilsMock.On("GetBufferedState", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.state, tt.args.stateErr)
 			merkleUtilsMock.On("CreateMerkle", mock.Anything).Return(tt.args.merkleTree, tt.args.merkleTreeErr)
 			cmdUtilsMock.On("GenerateTreeRevealData", mock.Anything, mock.Anything).Return(tt.args.treeRevealData)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.AnythingOfType("types.TransactionOptions")).Return(TxnOpts, tt.args.txnOptsErr)
 			voteManagerMock.On("Reveal", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("*bind.TransactOpts"), mock.AnythingOfType("uint32"), mock.Anything, mock.Anything).Return(tt.args.revealTxn, tt.args.revealErr)
 			transactionMock.On("Hash", mock.AnythingOfType("*types.Transaction")).Return(tt.args.hash)
 

--- a/cmd/setDelegation.go
+++ b/cmd/setDelegation.go
@@ -97,7 +97,11 @@ func (*UtilsStruct) SetDelegation(rpcParameters rpc.RPCParameters, config types.
 		return core.NilHash, nil
 	}
 	log.Infof("Setting delegation acceptance of Staker %d to %t", delegationInput.StakerId, delegationInput.Status)
-	setDelegationAcceptanceTxnOpts := razorUtils.GetTxnOpts(rpcParameters, txnOpts)
+	setDelegationAcceptanceTxnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnOpts)
+	if err != nil {
+		return core.NilHash, err
+	}
+
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {
 		return core.NilHash, err

--- a/cmd/setDelegation_test.go
+++ b/cmd/setDelegation_test.go
@@ -28,6 +28,7 @@ func TestSetDelegation(t *testing.T) {
 		status                     bool
 		staker                     bindings.StructsStaker
 		stakerErr                  error
+		txnOptsErr                 error
 		setDelegationAcceptanceTxn *Types.Transaction
 		setDelegationAcceptanceErr error
 		hash                       common.Hash
@@ -126,6 +127,17 @@ func TestSetDelegation(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("error in updating commission"),
 		},
+		{
+			name: "Test 7: When there is an error in getting txnOpts",
+			args: args{
+				staker: bindings.StructsStaker{
+					AcceptDelegation: true,
+				},
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -134,7 +146,7 @@ func TestSetDelegation(t *testing.T) {
 
 			utilsMock.On("GetStaker", mock.Anything, mock.Anything).Return(tt.args.staker, tt.args.stakerErr)
 			cmdUtilsMock.On("UpdateCommission", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.UpdateCommissionErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			stakeManagerMock.On("SetDelegationAcceptance", mock.AnythingOfType("*ethclient.Client"), mock.Anything, mock.AnythingOfType("bool")).Return(tt.args.setDelegationAcceptanceTxn, tt.args.setDelegationAcceptanceErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -80,7 +80,7 @@ func (*UtilsStruct) Transfer(rpcParameters rpc.RPCParameters, config types.Confi
 	log.Debug("Checking for sufficient balance...")
 	razorUtils.CheckAmountAndBalance(transferInput.ValueInWei, transferInput.Balance)
 
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.RAZORAddress,
@@ -89,6 +89,9 @@ func (*UtilsStruct) Transfer(rpcParameters rpc.RPCParameters, config types.Confi
 		ABI:             bindings.RAZORMetaData.ABI,
 		Account:         transferInput.Account,
 	})
+	if err != nil {
+		return core.NilHash, err
+	}
 	log.Infof("Transferring %g tokens from %s to %s", utils.GetAmountInDecimal(transferInput.ValueInWei), transferInput.Account.Address, transferInput.ToAddress)
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/unlockWithdraw.go
+++ b/cmd/unlockWithdraw.go
@@ -84,7 +84,10 @@ func (*UtilsStruct) HandleWithdrawLock(rpcParameters rpc.RPCParameters, account 
 			Parameters:      []interface{}{stakerId},
 			Account:         account,
 		}
-		txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+		txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+		if err != nil {
+			return core.NilHash, err
+		}
 		log.Debug("HandleWithdrawLock: Calling UnlockWithdraw() with arguments stakerId = ", stakerId)
 		return cmdUtils.UnlockWithdraw(rpcParameters, txnOpts, stakerId)
 	}

--- a/cmd/unlockWithdraw_test.go
+++ b/cmd/unlockWithdraw_test.go
@@ -127,6 +127,7 @@ func TestHandleWithdrawLock(t *testing.T) {
 		withdrawLockErr   error
 		epoch             uint32
 		epochErr          error
+		txnOptsErr        error
 		unlockWithdraw    common.Hash
 		unlockWithdrawErr error
 		time              string
@@ -191,6 +192,18 @@ func TestHandleWithdrawLock(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: false,
 		},
+		{
+			name: "Test 6: When there is an error in getting txnOpts",
+			args: args{
+				withdrawLock: types.Locks{
+					UnlockAfter: big.NewInt(4),
+				},
+				epoch:      5,
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -198,7 +211,7 @@ func TestHandleWithdrawLock(t *testing.T) {
 
 			utilsMock.On("GetLock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.withdrawLock, tt.args.withdrawLockErr)
 			utilsMock.On("GetEpoch", mock.Anything).Return(tt.args.epoch, tt.args.epochErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			cmdUtilsMock.On("UnlockWithdraw", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.unlockWithdraw, tt.args.unlockWithdrawErr)
 			utilsMock.On("SecondsToReadableTime", mock.AnythingOfType("int")).Return(tt.args.time)
 			ut := &UtilsStruct{}

--- a/cmd/unstake.go
+++ b/cmd/unstake.go
@@ -108,7 +108,10 @@ func (*UtilsStruct) Unstake(rpcParameters rpc.RPCParameters, config types.Config
 	}
 
 	txnArgs.Parameters = []interface{}{stakerId, txnArgs.Amount}
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 	log.Info("Unstaking coins")
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {
@@ -128,7 +131,10 @@ func (*UtilsStruct) Unstake(rpcParameters rpc.RPCParameters, config types.Config
 
 //This function approves the unstake
 func (*UtilsStruct) ApproveUnstake(rpcParameters rpc.RPCParameters, stakerTokenAddress common.Address, txnArgs types.TransactionOptions) (common.Hash, error) {
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnArgs)
+	if err != nil {
+		return core.NilHash, err
+	}
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {
 		return core.NilHash, err

--- a/cmd/updateCollection.go
+++ b/cmd/updateCollection.go
@@ -74,7 +74,7 @@ func (*UtilsStruct) UpdateCollection(rpcParameters rpc.RPCParameters, config typ
 		log.Error("Error in fetching state")
 		return core.NilHash, err
 	}
-	txnOpts := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnOpts, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.CollectionManagerAddress,
@@ -83,6 +83,9 @@ func (*UtilsStruct) UpdateCollection(rpcParameters rpc.RPCParameters, config typ
 		ABI:             bindings.CollectionManagerMetaData.ABI,
 		Account:         collectionInput.Account,
 	})
+	if err != nil {
+		return core.NilHash, err
+	}
 	log.Info("Updating collection...")
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/updateCollection_test.go
+++ b/cmd/updateCollection_test.go
@@ -23,6 +23,7 @@ func TestUpdateCollection(t *testing.T) {
 	var collectionId uint16
 
 	type args struct {
+		txnOptsErr           error
 		updateCollectionTxn  *Types.Transaction
 		updateCollectionErr  error
 		waitIfCommitStateErr error
@@ -68,13 +69,21 @@ func TestUpdateCollection(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("waitIfCommitState error"),
 		},
+		{
+			name: "Test 4: When there is an error in getting txnOpts",
+			args: args{
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
 			utilsMock.On("ConvertUintArrayToUint16Array", mock.Anything).Return(jobIdUint16)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			cmdUtilsMock.On("WaitIfCommitState", mock.Anything, mock.Anything).Return(WaitIfCommitStateStatus, tt.args.waitIfCommitStateErr)
 			assetManagerMock.On("UpdateCollection", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.updateCollectionTxn, tt.args.updateCollectionErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)

--- a/cmd/updateCommission.go
+++ b/cmd/updateCommission.go
@@ -101,7 +101,10 @@ func (*UtilsStruct) UpdateCommission(rpcParameters rpc.RPCParameters, config typ
 		Parameters:      []interface{}{updateCommissionInput.Commission},
 		Account:         updateCommissionInput.Account,
 	}
-	updateCommissionTxnOpts := razorUtils.GetTxnOpts(rpcParameters, txnOpts)
+	updateCommissionTxnOpts, err := razorUtils.GetTxnOpts(rpcParameters, txnOpts)
+	if err != nil {
+		return err
+	}
 	log.Infof("Setting the commission value of Staker %d to %d%%", updateCommissionInput.StakerId, updateCommissionInput.Commission)
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -33,6 +33,7 @@ func TestUpdateCommission(t *testing.T) {
 		epoch                            uint32
 		epochErr                         error
 		time                             string
+		txnOptsErr                       error
 		UpdateCommissionTxn              *Types.Transaction
 		UpdateCommissionErr              error
 		hash                             common.Hash
@@ -184,13 +185,25 @@ func TestUpdateCommission(t *testing.T) {
 			},
 			wantErr: errors.New("invalid epoch for update"),
 		},
+		{
+			name: "Test 11: When there is an error in getting txnOpts",
+			args: args{
+				commission:                    10,
+				stakerInfo:                    bindings.StructsStaker{},
+				maxCommission:                 20,
+				epochLimitForUpdateCommission: 10,
+				epoch:                         11,
+				txnOptsErr:                    errors.New("txnOpts error"),
+			},
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
 			utilsMock.On("GetStaker", mock.Anything, mock.Anything).Return(tt.args.stakerInfo, tt.args.stakerInfoErr)
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			utilsMock.On("GetEpoch", mock.Anything).Return(tt.args.epoch, tt.args.epochErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)

--- a/cmd/updateJob.go
+++ b/cmd/updateJob.go
@@ -77,7 +77,7 @@ func (*UtilsStruct) UpdateJob(rpcParameters rpc.RPCParameters, config types.Conf
 		log.Error("Error in fetching state")
 		return core.NilHash, err
 	}
-	txnArgs := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
+	txnArgs, err := razorUtils.GetTxnOpts(rpcParameters, types.TransactionOptions{
 		ChainId:         core.ChainId,
 		Config:          config,
 		ContractAddress: core.CollectionManagerAddress,
@@ -86,6 +86,9 @@ func (*UtilsStruct) UpdateJob(rpcParameters rpc.RPCParameters, config types.Conf
 		ABI:             bindings.CollectionManagerMetaData.ABI,
 		Account:         jobInput.Account,
 	})
+	if err != nil {
+		return core.NilHash, err
+	}
 	log.Info("Updating Job...")
 	client, err := rpcParameters.RPCManager.GetBestRPCClient()
 	if err != nil {

--- a/cmd/updateJob_test.go
+++ b/cmd/updateJob_test.go
@@ -22,6 +22,7 @@ func TestUpdateJob(t *testing.T) {
 	var jobId uint16
 
 	type args struct {
+		txnOptsErr           error
 		updateJobTxn         *Types.Transaction
 		updateJobErr         error
 		waitIfCommitStateErr error
@@ -62,12 +63,20 @@ func TestUpdateJob(t *testing.T) {
 			want:    core.NilHash,
 			wantErr: errors.New("waitIfCommitState error"),
 		},
+		{
+			name: "Test 4:  When there is an error in getting txnOpts",
+			args: args{
+				txnOptsErr: errors.New("txnOpts error"),
+			},
+			want:    core.NilHash,
+			wantErr: errors.New("txnOpts error"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 
-			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
+			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts, tt.args.txnOptsErr)
 			cmdUtilsMock.On("WaitIfCommitState", mock.Anything, mock.Anything, mock.Anything).Return(WaitIfCommitStateStatus, tt.args.waitIfCommitStateErr)
 			assetManagerMock.On("UpdateJob", mock.AnythingOfType("*ethclient.Client"), mock.AnythingOfType("*bind.TransactOpts"), mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.updateJobTxn, tt.args.updateJobErr)
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -73,7 +73,7 @@ var GasInterface GasUtils
 
 type Utils interface {
 	MultiplyFloatAndBigInt(bigIntVal *big.Int, floatingVal float64) *big.Int
-	GetTxnOpts(rpcParameters rpc.RPCParameters, transactionData types.TransactionOptions) *bind.TransactOpts
+	GetTxnOpts(rpcParameters rpc.RPCParameters, transactionData types.TransactionOptions) (*bind.TransactOpts, error)
 	GetBlockManager(client *ethclient.Client) *bindings.BlockManager
 	GetOptions() bind.CallOpts
 	GetNumberOfProposedBlocks(rpcParameters rpc.RPCParameters, epoch uint32) (uint8, error)

--- a/utils/mocks/utils.go
+++ b/utils/mocks/utils.go
@@ -4,8 +4,6 @@ package mocks
 
 import (
 	big "math/big"
-	RPC "razor/rpc"
-
 	bindings "razor/pkg/bindings"
 
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -21,6 +19,8 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	pflag "github.com/spf13/pflag"
+
+	rpc "razor/rpc"
 
 	types "razor/core/types"
 )
@@ -71,15 +71,15 @@ func (_m *Utils) AddJobToJSON(fileName string, job *types.StructsJob) error {
 }
 
 // Aggregate provides a mock function with given fields: rpcParameters, previousEpoch, collection, commitParams
-func (_m *Utils) Aggregate(rpcParameters RPC.RPCParameters, previousEpoch uint32, collection bindings.StructsCollection, commitParams *types.CommitParams) (*big.Int, error) {
+func (_m *Utils) Aggregate(rpcParameters rpc.RPCParameters, previousEpoch uint32, collection bindings.StructsCollection, commitParams *types.CommitParams) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, previousEpoch, collection, commitParams)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, bindings.StructsCollection, *types.CommitParams) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, bindings.StructsCollection, *types.CommitParams) (*big.Int, error)); ok {
 		return rf(rpcParameters, previousEpoch, collection, commitParams)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, bindings.StructsCollection, *types.CommitParams) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, bindings.StructsCollection, *types.CommitParams) *big.Int); ok {
 		r0 = rf(rpcParameters, previousEpoch, collection, commitParams)
 	} else {
 		if ret.Get(0) != nil {
@@ -87,7 +87,7 @@ func (_m *Utils) Aggregate(rpcParameters RPC.RPCParameters, previousEpoch uint32
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, bindings.StructsCollection, *types.CommitParams) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, bindings.StructsCollection, *types.CommitParams) error); ok {
 		r1 = rf(rpcParameters, previousEpoch, collection, commitParams)
 	} else {
 		r1 = ret.Error(1)
@@ -97,15 +97,15 @@ func (_m *Utils) Aggregate(rpcParameters RPC.RPCParameters, previousEpoch uint32
 }
 
 // Allowance provides a mock function with given fields: rpcParameters, owner, spender
-func (_m *Utils) Allowance(rpcParameters RPC.RPCParameters, owner common.Address, spender common.Address) (*big.Int, error) {
+func (_m *Utils) Allowance(rpcParameters rpc.RPCParameters, owner common.Address, spender common.Address) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, owner, spender)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, common.Address, common.Address) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, common.Address, common.Address) (*big.Int, error)); ok {
 		return rf(rpcParameters, owner, spender)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, common.Address, common.Address) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, common.Address, common.Address) *big.Int); ok {
 		r0 = rf(rpcParameters, owner, spender)
 	} else {
 		if ret.Get(0) != nil {
@@ -113,7 +113,7 @@ func (_m *Utils) Allowance(rpcParameters RPC.RPCParameters, owner common.Address
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, common.Address, common.Address) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, common.Address, common.Address) error); ok {
 		r1 = rf(rpcParameters, owner, spender)
 	} else {
 		r1 = ret.Error(1)
@@ -137,21 +137,21 @@ func (_m *Utils) AssignPassword(flagSet *pflag.FlagSet) string {
 }
 
 // AssignStakerId provides a mock function with given fields: rpcParameters, flagSet, address
-func (_m *Utils) AssignStakerId(rpcParameters RPC.RPCParameters, flagSet *pflag.FlagSet, address string) (uint32, error) {
+func (_m *Utils) AssignStakerId(rpcParameters rpc.RPCParameters, flagSet *pflag.FlagSet, address string) (uint32, error) {
 	ret := _m.Called(rpcParameters, flagSet, address)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, *pflag.FlagSet, string) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, *pflag.FlagSet, string) (uint32, error)); ok {
 		return rf(rpcParameters, flagSet, address)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, *pflag.FlagSet, string) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, *pflag.FlagSet, string) uint32); ok {
 		r0 = rf(rpcParameters, flagSet, address)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, *pflag.FlagSet, string) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, *pflag.FlagSet, string) error); ok {
 		r1 = rf(rpcParameters, flagSet, address)
 	} else {
 		r1 = ret.Error(1)
@@ -161,11 +161,11 @@ func (_m *Utils) AssignStakerId(rpcParameters RPC.RPCParameters, flagSet *pflag.
 }
 
 // CalculateBlockTime provides a mock function with given fields: rpcParameters
-func (_m *Utils) CalculateBlockTime(rpcParameters RPC.RPCParameters) int64 {
+func (_m *Utils) CalculateBlockTime(rpcParameters rpc.RPCParameters) int64 {
 	ret := _m.Called(rpcParameters)
 
 	var r0 int64
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) int64); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) int64); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(int64)
@@ -207,7 +207,7 @@ func (_m *Utils) CheckAmountAndBalance(amountInWei *big.Int, balance *big.Int) *
 }
 
 // CheckEthBalanceIsZero provides a mock function with given fields: rpcParameters, address
-func (_m *Utils) CheckEthBalanceIsZero(rpcParameters RPC.RPCParameters, address string) {
+func (_m *Utils) CheckEthBalanceIsZero(rpcParameters rpc.RPCParameters, address string) {
 	_m.Called(rpcParameters, address)
 }
 
@@ -226,11 +226,11 @@ func (_m *Utils) CheckPassword(account types.Account) error {
 }
 
 // CheckTransactionReceipt provides a mock function with given fields: rpcManager, _txHash
-func (_m *Utils) CheckTransactionReceipt(rpcManager RPC.RPCParameters, _txHash string) int {
+func (_m *Utils) CheckTransactionReceipt(rpcManager rpc.RPCParameters, _txHash string) int {
 	ret := _m.Called(rpcManager, _txHash)
 
 	var r0 int
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) int); ok {
 		r0 = rf(rpcManager, _txHash)
 	} else {
 		r0 = ret.Get(0).(int)
@@ -270,21 +270,21 @@ func (_m *Utils) DeleteJobFromJSON(fileName string, jobId string) error {
 }
 
 // Disputes provides a mock function with given fields: rpcParameters, epoch, address
-func (_m *Utils) Disputes(rpcParameters RPC.RPCParameters, epoch uint32, address common.Address) (types.DisputesStruct, error) {
+func (_m *Utils) Disputes(rpcParameters rpc.RPCParameters, epoch uint32, address common.Address) (types.DisputesStruct, error) {
 	ret := _m.Called(rpcParameters, epoch, address)
 
 	var r0 types.DisputesStruct
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, common.Address) (types.DisputesStruct, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, common.Address) (types.DisputesStruct, error)); ok {
 		return rf(rpcParameters, epoch, address)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, common.Address) types.DisputesStruct); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, common.Address) types.DisputesStruct); ok {
 		r0 = rf(rpcParameters, epoch, address)
 	} else {
 		r0 = ret.Get(0).(types.DisputesStruct)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, common.Address) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, common.Address) error); ok {
 		r1 = rf(rpcParameters, epoch, address)
 	} else {
 		r1 = ret.Error(1)
@@ -294,15 +294,15 @@ func (_m *Utils) Disputes(rpcParameters RPC.RPCParameters, epoch uint32, address
 }
 
 // EstimateBlockNumberAtEpochBeginning provides a mock function with given fields: rpcParameters, currentBlockNumber
-func (_m *Utils) EstimateBlockNumberAtEpochBeginning(rpcParameters RPC.RPCParameters, currentBlockNumber *big.Int) (*big.Int, error) {
+func (_m *Utils) EstimateBlockNumberAtEpochBeginning(rpcParameters rpc.RPCParameters, currentBlockNumber *big.Int) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, currentBlockNumber)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, *big.Int) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, *big.Int) (*big.Int, error)); ok {
 		return rf(rpcParameters, currentBlockNumber)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, *big.Int) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, *big.Int) *big.Int); ok {
 		r0 = rf(rpcParameters, currentBlockNumber)
 	} else {
 		if ret.Get(0) != nil {
@@ -310,7 +310,7 @@ func (_m *Utils) EstimateBlockNumberAtEpochBeginning(rpcParameters RPC.RPCParame
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, *big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, *big.Int) error); ok {
 		r1 = rf(rpcParameters, currentBlockNumber)
 	} else {
 		r1 = ret.Error(1)
@@ -320,15 +320,15 @@ func (_m *Utils) EstimateBlockNumberAtEpochBeginning(rpcParameters RPC.RPCParame
 }
 
 // FetchBalance provides a mock function with given fields: rpcParameters, accountAddress
-func (_m *Utils) FetchBalance(rpcParameters RPC.RPCParameters, accountAddress string) (*big.Int, error) {
+func (_m *Utils) FetchBalance(rpcParameters rpc.RPCParameters, accountAddress string) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, accountAddress)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) (*big.Int, error)); ok {
 		return rf(rpcParameters, accountAddress)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) *big.Int); ok {
 		r0 = rf(rpcParameters, accountAddress)
 	} else {
 		if ret.Get(0) != nil {
@@ -336,7 +336,7 @@ func (_m *Utils) FetchBalance(rpcParameters RPC.RPCParameters, accountAddress st
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, string) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, string) error); ok {
 		r1 = rf(rpcParameters, accountAddress)
 	} else {
 		r1 = ret.Error(1)
@@ -346,15 +346,15 @@ func (_m *Utils) FetchBalance(rpcParameters RPC.RPCParameters, accountAddress st
 }
 
 // FetchPreviousValue provides a mock function with given fields: rpcParameters, epoch, assetId
-func (_m *Utils) FetchPreviousValue(rpcParameters RPC.RPCParameters, epoch uint32, assetId uint16) (*big.Int, error) {
+func (_m *Utils) FetchPreviousValue(rpcParameters rpc.RPCParameters, epoch uint32, assetId uint16) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, epoch, assetId)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint16) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint16) (*big.Int, error)); ok {
 		return rf(rpcParameters, epoch, assetId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint16) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint16) *big.Int); ok {
 		r0 = rf(rpcParameters, epoch, assetId)
 	} else {
 		if ret.Get(0) != nil {
@@ -362,7 +362,7 @@ func (_m *Utils) FetchPreviousValue(rpcParameters RPC.RPCParameters, epoch uint3
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, uint16) error); ok {
 		r1 = rf(rpcParameters, epoch, assetId)
 	} else {
 		r1 = ret.Error(1)
@@ -396,15 +396,15 @@ func (_m *Utils) GetActiveCollection(collectionsCache *cache.CollectionsCache, c
 }
 
 // GetActiveCollectionIds provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetActiveCollectionIds(rpcParameters RPC.RPCParameters) ([]uint16, error) {
+func (_m *Utils) GetActiveCollectionIds(rpcParameters rpc.RPCParameters) ([]uint16, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 []uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) ([]uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) ([]uint16, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) []uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) []uint16); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		if ret.Get(0) != nil {
@@ -412,7 +412,7 @@ func (_m *Utils) GetActiveCollectionIds(rpcParameters RPC.RPCParameters) ([]uint
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -422,21 +422,21 @@ func (_m *Utils) GetActiveCollectionIds(rpcParameters RPC.RPCParameters) ([]uint
 }
 
 // GetActiveJob provides a mock function with given fields: rpcParameters, jobId
-func (_m *Utils) GetActiveJob(rpcParameters RPC.RPCParameters, jobId uint16) (bindings.StructsJob, error) {
+func (_m *Utils) GetActiveJob(rpcParameters rpc.RPCParameters, jobId uint16) (bindings.StructsJob, error) {
 	ret := _m.Called(rpcParameters, jobId)
 
 	var r0 bindings.StructsJob
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) (bindings.StructsJob, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) (bindings.StructsJob, error)); ok {
 		return rf(rpcParameters, jobId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) bindings.StructsJob); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) bindings.StructsJob); ok {
 		r0 = rf(rpcParameters, jobId)
 	} else {
 		r0 = ret.Get(0).(bindings.StructsJob)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16) error); ok {
 		r1 = rf(rpcParameters, jobId)
 	} else {
 		r1 = ret.Error(1)
@@ -446,21 +446,21 @@ func (_m *Utils) GetActiveJob(rpcParameters RPC.RPCParameters, jobId uint16) (bi
 }
 
 // GetActiveStatus provides a mock function with given fields: rpcParameters, id
-func (_m *Utils) GetActiveStatus(rpcParameters RPC.RPCParameters, id uint16) (bool, error) {
+func (_m *Utils) GetActiveStatus(rpcParameters rpc.RPCParameters, id uint16) (bool, error) {
 	ret := _m.Called(rpcParameters, id)
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) (bool, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) (bool, error)); ok {
 		return rf(rpcParameters, id)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) bool); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) bool); ok {
 		r0 = rf(rpcParameters, id)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16) error); ok {
 		r1 = rf(rpcParameters, id)
 	} else {
 		r1 = ret.Error(1)
@@ -470,15 +470,15 @@ func (_m *Utils) GetActiveStatus(rpcParameters RPC.RPCParameters, id uint16) (bo
 }
 
 // GetAggregatedDataOfCollection provides a mock function with given fields: rpcParameters, collectionId, epoch, commitParams
-func (_m *Utils) GetAggregatedDataOfCollection(rpcParameters RPC.RPCParameters, collectionId uint16, epoch uint32, commitParams *types.CommitParams) (*big.Int, error) {
+func (_m *Utils) GetAggregatedDataOfCollection(rpcParameters rpc.RPCParameters, collectionId uint16, epoch uint32, commitParams *types.CommitParams) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, collectionId, epoch, commitParams)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16, uint32, *types.CommitParams) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16, uint32, *types.CommitParams) (*big.Int, error)); ok {
 		return rf(rpcParameters, collectionId, epoch, commitParams)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16, uint32, *types.CommitParams) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16, uint32, *types.CommitParams) *big.Int); ok {
 		r0 = rf(rpcParameters, collectionId, epoch, commitParams)
 	} else {
 		if ret.Get(0) != nil {
@@ -486,7 +486,7 @@ func (_m *Utils) GetAggregatedDataOfCollection(rpcParameters RPC.RPCParameters, 
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16, uint32, *types.CommitParams) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16, uint32, *types.CommitParams) error); ok {
 		r1 = rf(rpcParameters, collectionId, epoch, commitParams)
 	} else {
 		r1 = ret.Error(1)
@@ -496,15 +496,15 @@ func (_m *Utils) GetAggregatedDataOfCollection(rpcParameters RPC.RPCParameters, 
 }
 
 // GetAllCollections provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetAllCollections(rpcParameters RPC.RPCParameters) ([]bindings.StructsCollection, error) {
+func (_m *Utils) GetAllCollections(rpcParameters rpc.RPCParameters) ([]bindings.StructsCollection, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 []bindings.StructsCollection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) ([]bindings.StructsCollection, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) ([]bindings.StructsCollection, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) []bindings.StructsCollection); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) []bindings.StructsCollection); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		if ret.Get(0) != nil {
@@ -512,7 +512,7 @@ func (_m *Utils) GetAllCollections(rpcParameters RPC.RPCParameters) ([]bindings.
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -522,16 +522,16 @@ func (_m *Utils) GetAllCollections(rpcParameters RPC.RPCParameters) ([]bindings.
 }
 
 // GetAssignedCollections provides a mock function with given fields: rpcParameters, numActiveCollections, seed
-func (_m *Utils) GetAssignedCollections(rpcParameters RPC.RPCParameters, numActiveCollections uint16, seed []byte) (map[int]bool, []*big.Int, error) {
+func (_m *Utils) GetAssignedCollections(rpcParameters rpc.RPCParameters, numActiveCollections uint16, seed []byte) (map[int]bool, []*big.Int, error) {
 	ret := _m.Called(rpcParameters, numActiveCollections, seed)
 
 	var r0 map[int]bool
 	var r1 []*big.Int
 	var r2 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16, []byte) (map[int]bool, []*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16, []byte) (map[int]bool, []*big.Int, error)); ok {
 		return rf(rpcParameters, numActiveCollections, seed)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16, []byte) map[int]bool); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16, []byte) map[int]bool); ok {
 		r0 = rf(rpcParameters, numActiveCollections, seed)
 	} else {
 		if ret.Get(0) != nil {
@@ -539,7 +539,7 @@ func (_m *Utils) GetAssignedCollections(rpcParameters RPC.RPCParameters, numActi
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16, []byte) []*big.Int); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16, []byte) []*big.Int); ok {
 		r1 = rf(rpcParameters, numActiveCollections, seed)
 	} else {
 		if ret.Get(1) != nil {
@@ -547,7 +547,7 @@ func (_m *Utils) GetAssignedCollections(rpcParameters RPC.RPCParameters, numActi
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(RPC.RPCParameters, uint16, []byte) error); ok {
+	if rf, ok := ret.Get(2).(func(rpc.RPCParameters, uint16, []byte) error); ok {
 		r2 = rf(rpcParameters, numActiveCollections, seed)
 	} else {
 		r2 = ret.Error(2)
@@ -557,21 +557,21 @@ func (_m *Utils) GetAssignedCollections(rpcParameters RPC.RPCParameters, numActi
 }
 
 // GetBlock provides a mock function with given fields: rpcParameters, epoch
-func (_m *Utils) GetBlock(rpcParameters RPC.RPCParameters, epoch uint32) (bindings.StructsBlock, error) {
+func (_m *Utils) GetBlock(rpcParameters rpc.RPCParameters, epoch uint32) (bindings.StructsBlock, error) {
 	ret := _m.Called(rpcParameters, epoch)
 
 	var r0 bindings.StructsBlock
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (bindings.StructsBlock, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (bindings.StructsBlock, error)); ok {
 		return rf(rpcParameters, epoch)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) bindings.StructsBlock); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) bindings.StructsBlock); ok {
 		r0 = rf(rpcParameters, epoch)
 	} else {
 		r0 = ret.Get(0).(bindings.StructsBlock)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, epoch)
 	} else {
 		r1 = ret.Error(1)
@@ -581,21 +581,21 @@ func (_m *Utils) GetBlock(rpcParameters RPC.RPCParameters, epoch uint32) (bindin
 }
 
 // GetBlockIndexToBeConfirmed provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetBlockIndexToBeConfirmed(rpcParameters RPC.RPCParameters) (int8, error) {
+func (_m *Utils) GetBlockIndexToBeConfirmed(rpcParameters rpc.RPCParameters) (int8, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 int8
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (int8, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (int8, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) int8); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) int8); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(int8)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -647,21 +647,21 @@ func (_m *Utils) GetBlockManagerWithOpts(client *ethclient.Client) (*bindings.Bl
 }
 
 // GetBountyLock provides a mock function with given fields: rpcParameters, bountyId
-func (_m *Utils) GetBountyLock(rpcParameters RPC.RPCParameters, bountyId uint32) (types.BountyLock, error) {
+func (_m *Utils) GetBountyLock(rpcParameters rpc.RPCParameters, bountyId uint32) (types.BountyLock, error) {
 	ret := _m.Called(rpcParameters, bountyId)
 
 	var r0 types.BountyLock
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (types.BountyLock, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (types.BountyLock, error)); ok {
 		return rf(rpcParameters, bountyId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) types.BountyLock); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) types.BountyLock); ok {
 		r0 = rf(rpcParameters, bountyId)
 	} else {
 		r0 = ret.Get(0).(types.BountyLock)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, bountyId)
 	} else {
 		r1 = ret.Error(1)
@@ -695,21 +695,21 @@ func (_m *Utils) GetBufferedState(header *coretypes.Header, stateBuffer uint64, 
 }
 
 // GetCollection provides a mock function with given fields: rpcParameters, collectionId
-func (_m *Utils) GetCollection(rpcParameters RPC.RPCParameters, collectionId uint16) (bindings.StructsCollection, error) {
+func (_m *Utils) GetCollection(rpcParameters rpc.RPCParameters, collectionId uint16) (bindings.StructsCollection, error) {
 	ret := _m.Called(rpcParameters, collectionId)
 
 	var r0 bindings.StructsCollection
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) (bindings.StructsCollection, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) (bindings.StructsCollection, error)); ok {
 		return rf(rpcParameters, collectionId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) bindings.StructsCollection); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) bindings.StructsCollection); ok {
 		r0 = rf(rpcParameters, collectionId)
 	} else {
 		r0 = ret.Get(0).(bindings.StructsCollection)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16) error); ok {
 		r1 = rf(rpcParameters, collectionId)
 	} else {
 		r1 = ret.Error(1)
@@ -719,21 +719,21 @@ func (_m *Utils) GetCollection(rpcParameters RPC.RPCParameters, collectionId uin
 }
 
 // GetCollectionIdFromIndex provides a mock function with given fields: rpcParameters, medianIndex
-func (_m *Utils) GetCollectionIdFromIndex(rpcParameters RPC.RPCParameters, medianIndex uint16) (uint16, error) {
+func (_m *Utils) GetCollectionIdFromIndex(rpcParameters rpc.RPCParameters, medianIndex uint16) (uint16, error) {
 	ret := _m.Called(rpcParameters, medianIndex)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) (uint16, error)); ok {
 		return rf(rpcParameters, medianIndex)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) uint16); ok {
 		r0 = rf(rpcParameters, medianIndex)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16) error); ok {
 		r1 = rf(rpcParameters, medianIndex)
 	} else {
 		r1 = ret.Error(1)
@@ -743,21 +743,21 @@ func (_m *Utils) GetCollectionIdFromIndex(rpcParameters RPC.RPCParameters, media
 }
 
 // GetCollectionIdFromLeafId provides a mock function with given fields: rpcParameters, leafId
-func (_m *Utils) GetCollectionIdFromLeafId(rpcParameters RPC.RPCParameters, leafId uint16) (uint16, error) {
+func (_m *Utils) GetCollectionIdFromLeafId(rpcParameters rpc.RPCParameters, leafId uint16) (uint16, error) {
 	ret := _m.Called(rpcParameters, leafId)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) (uint16, error)); ok {
 		return rf(rpcParameters, leafId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) uint16); ok {
 		r0 = rf(rpcParameters, leafId)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16) error); ok {
 		r1 = rf(rpcParameters, leafId)
 	} else {
 		r1 = ret.Error(1)
@@ -809,21 +809,21 @@ func (_m *Utils) GetCollectionManagerWithOpts(client *ethclient.Client) (*bindin
 }
 
 // GetCommitment provides a mock function with given fields: rpcParameters, address
-func (_m *Utils) GetCommitment(rpcParameters RPC.RPCParameters, address string) (types.Commitment, error) {
+func (_m *Utils) GetCommitment(rpcParameters rpc.RPCParameters, address string) (types.Commitment, error) {
 	ret := _m.Called(rpcParameters, address)
 
 	var r0 types.Commitment
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) (types.Commitment, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) (types.Commitment, error)); ok {
 		return rf(rpcParameters, address)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) types.Commitment); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) types.Commitment); ok {
 		r0 = rf(rpcParameters, address)
 	} else {
 		r0 = ret.Get(0).(types.Commitment)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, string) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, string) error); ok {
 		r1 = rf(rpcParameters, address)
 	} else {
 		r1 = ret.Error(1)
@@ -833,21 +833,21 @@ func (_m *Utils) GetCommitment(rpcParameters RPC.RPCParameters, address string) 
 }
 
 // GetConfirmedBlocks provides a mock function with given fields: rpcParameters, epoch
-func (_m *Utils) GetConfirmedBlocks(rpcParameters RPC.RPCParameters, epoch uint32) (types.ConfirmedBlock, error) {
+func (_m *Utils) GetConfirmedBlocks(rpcParameters rpc.RPCParameters, epoch uint32) (types.ConfirmedBlock, error) {
 	ret := _m.Called(rpcParameters, epoch)
 
 	var r0 types.ConfirmedBlock
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (types.ConfirmedBlock, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (types.ConfirmedBlock, error)); ok {
 		return rf(rpcParameters, epoch)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) types.ConfirmedBlock); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) types.ConfirmedBlock); ok {
 		r0 = rf(rpcParameters, epoch)
 	} else {
 		r0 = ret.Get(0).(types.ConfirmedBlock)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, epoch)
 	} else {
 		r1 = ret.Error(1)
@@ -911,21 +911,21 @@ func (_m *Utils) GetDataToCommitFromJobs(jobs []bindings.StructsJob, commitParam
 }
 
 // GetEpoch provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetEpoch(rpcParameters RPC.RPCParameters) (uint32, error) {
+func (_m *Utils) GetEpoch(rpcParameters rpc.RPCParameters) (uint32, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint32, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint32); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -935,21 +935,21 @@ func (_m *Utils) GetEpoch(rpcParameters RPC.RPCParameters) (uint32, error) {
 }
 
 // GetEpochLastCommitted provides a mock function with given fields: rpcParameters, stakerId
-func (_m *Utils) GetEpochLastCommitted(rpcParameters RPC.RPCParameters, stakerId uint32) (uint32, error) {
+func (_m *Utils) GetEpochLastCommitted(rpcParameters rpc.RPCParameters, stakerId uint32) (uint32, error) {
 	ret := _m.Called(rpcParameters, stakerId)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (uint32, error)); ok {
 		return rf(rpcParameters, stakerId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) uint32); ok {
 		r0 = rf(rpcParameters, stakerId)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId)
 	} else {
 		r1 = ret.Error(1)
@@ -959,21 +959,21 @@ func (_m *Utils) GetEpochLastCommitted(rpcParameters RPC.RPCParameters, stakerId
 }
 
 // GetEpochLastProposed provides a mock function with given fields: rpcParameters, stakerId
-func (_m *Utils) GetEpochLastProposed(rpcParameters RPC.RPCParameters, stakerId uint32) (uint32, error) {
+func (_m *Utils) GetEpochLastProposed(rpcParameters rpc.RPCParameters, stakerId uint32) (uint32, error) {
 	ret := _m.Called(rpcParameters, stakerId)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (uint32, error)); ok {
 		return rf(rpcParameters, stakerId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) uint32); ok {
 		r0 = rf(rpcParameters, stakerId)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId)
 	} else {
 		r1 = ret.Error(1)
@@ -983,21 +983,21 @@ func (_m *Utils) GetEpochLastProposed(rpcParameters RPC.RPCParameters, stakerId 
 }
 
 // GetEpochLastRevealed provides a mock function with given fields: rpcParameters, stakerId
-func (_m *Utils) GetEpochLastRevealed(rpcParameters RPC.RPCParameters, stakerId uint32) (uint32, error) {
+func (_m *Utils) GetEpochLastRevealed(rpcParameters rpc.RPCParameters, stakerId uint32) (uint32, error) {
 	ret := _m.Called(rpcParameters, stakerId)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (uint32, error)); ok {
 		return rf(rpcParameters, stakerId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) uint32); ok {
 		r0 = rf(rpcParameters, stakerId)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId)
 	} else {
 		r1 = ret.Error(1)
@@ -1007,21 +1007,21 @@ func (_m *Utils) GetEpochLastRevealed(rpcParameters RPC.RPCParameters, stakerId 
 }
 
 // GetEpochLimitForUpdateCommission provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetEpochLimitForUpdateCommission(rpcParameters RPC.RPCParameters) (uint16, error) {
+func (_m *Utils) GetEpochLimitForUpdateCommission(rpcParameters rpc.RPCParameters) (uint16, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint16, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint16); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1031,15 +1031,15 @@ func (_m *Utils) GetEpochLimitForUpdateCommission(rpcParameters RPC.RPCParameter
 }
 
 // GetInfluenceSnapshot provides a mock function with given fields: rpcParameters, stakerId, epoch
-func (_m *Utils) GetInfluenceSnapshot(rpcParameters RPC.RPCParameters, stakerId uint32, epoch uint32) (*big.Int, error) {
+func (_m *Utils) GetInfluenceSnapshot(rpcParameters rpc.RPCParameters, stakerId uint32, epoch uint32) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, stakerId, epoch)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32) (*big.Int, error)); ok {
 		return rf(rpcParameters, stakerId, epoch)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32) *big.Int); ok {
 		r0 = rf(rpcParameters, stakerId, epoch)
 	} else {
 		if ret.Get(0) != nil {
@@ -1047,7 +1047,7 @@ func (_m *Utils) GetInfluenceSnapshot(rpcParameters RPC.RPCParameters, stakerId 
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId, epoch)
 	} else {
 		r1 = ret.Error(1)
@@ -1057,15 +1057,15 @@ func (_m *Utils) GetInfluenceSnapshot(rpcParameters RPC.RPCParameters, stakerId 
 }
 
 // GetJobs provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetJobs(rpcParameters RPC.RPCParameters) ([]bindings.StructsJob, error) {
+func (_m *Utils) GetJobs(rpcParameters rpc.RPCParameters) ([]bindings.StructsJob, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 []bindings.StructsJob
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) ([]bindings.StructsJob, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) ([]bindings.StructsJob, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) []bindings.StructsJob); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) []bindings.StructsJob); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		if ret.Get(0) != nil {
@@ -1073,7 +1073,7 @@ func (_m *Utils) GetJobs(rpcParameters RPC.RPCParameters) ([]bindings.StructsJob
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1083,21 +1083,21 @@ func (_m *Utils) GetJobs(rpcParameters RPC.RPCParameters) ([]bindings.StructsJob
 }
 
 // GetLeafIdOfACollection provides a mock function with given fields: rpcParameters, collectionId
-func (_m *Utils) GetLeafIdOfACollection(rpcParameters RPC.RPCParameters, collectionId uint16) (uint16, error) {
+func (_m *Utils) GetLeafIdOfACollection(rpcParameters rpc.RPCParameters, collectionId uint16) (uint16, error) {
 	ret := _m.Called(rpcParameters, collectionId)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) (uint16, error)); ok {
 		return rf(rpcParameters, collectionId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint16) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint16) uint16); ok {
 		r0 = rf(rpcParameters, collectionId)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint16) error); ok {
 		r1 = rf(rpcParameters, collectionId)
 	} else {
 		r1 = ret.Error(1)
@@ -1107,21 +1107,21 @@ func (_m *Utils) GetLeafIdOfACollection(rpcParameters RPC.RPCParameters, collect
 }
 
 // GetLock provides a mock function with given fields: rpcParameters, address, stakerId, lockType
-func (_m *Utils) GetLock(rpcParameters RPC.RPCParameters, address string, stakerId uint32, lockType uint8) (types.Locks, error) {
+func (_m *Utils) GetLock(rpcParameters rpc.RPCParameters, address string, stakerId uint32, lockType uint8) (types.Locks, error) {
 	ret := _m.Called(rpcParameters, address, stakerId, lockType)
 
 	var r0 types.Locks
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string, uint32, uint8) (types.Locks, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string, uint32, uint8) (types.Locks, error)); ok {
 		return rf(rpcParameters, address, stakerId, lockType)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string, uint32, uint8) types.Locks); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string, uint32, uint8) types.Locks); ok {
 		r0 = rf(rpcParameters, address, stakerId, lockType)
 	} else {
 		r0 = ret.Get(0).(types.Locks)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, string, uint32, uint8) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, string, uint32, uint8) error); ok {
 		r1 = rf(rpcParameters, address, stakerId, lockType)
 	} else {
 		r1 = ret.Error(1)
@@ -1131,21 +1131,21 @@ func (_m *Utils) GetLock(rpcParameters RPC.RPCParameters, address string, staker
 }
 
 // GetMaturity provides a mock function with given fields: rpcParameters, age
-func (_m *Utils) GetMaturity(rpcParameters RPC.RPCParameters, age uint32) (uint16, error) {
+func (_m *Utils) GetMaturity(rpcParameters rpc.RPCParameters, age uint32) (uint16, error) {
 	ret := _m.Called(rpcParameters, age)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (uint16, error)); ok {
 		return rf(rpcParameters, age)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) uint16); ok {
 		r0 = rf(rpcParameters, age)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, age)
 	} else {
 		r1 = ret.Error(1)
@@ -1155,21 +1155,21 @@ func (_m *Utils) GetMaturity(rpcParameters RPC.RPCParameters, age uint32) (uint1
 }
 
 // GetMaxAltBlocks provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetMaxAltBlocks(rpcParameters RPC.RPCParameters) (uint8, error) {
+func (_m *Utils) GetMaxAltBlocks(rpcParameters rpc.RPCParameters) (uint8, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint8
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint8, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint8, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint8); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint8); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint8)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1179,21 +1179,21 @@ func (_m *Utils) GetMaxAltBlocks(rpcParameters RPC.RPCParameters) (uint8, error)
 }
 
 // GetMaxCommission provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetMaxCommission(rpcParameters RPC.RPCParameters) (uint8, error) {
+func (_m *Utils) GetMaxCommission(rpcParameters rpc.RPCParameters) (uint8, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint8
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint8, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint8, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint8); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint8); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint8)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1203,15 +1203,15 @@ func (_m *Utils) GetMaxCommission(rpcParameters RPC.RPCParameters) (uint8, error
 }
 
 // GetMinSafeRazor provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetMinSafeRazor(rpcParameters RPC.RPCParameters) (*big.Int, error) {
+func (_m *Utils) GetMinSafeRazor(rpcParameters rpc.RPCParameters) (*big.Int, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (*big.Int, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) *big.Int); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		if ret.Get(0) != nil {
@@ -1219,7 +1219,7 @@ func (_m *Utils) GetMinSafeRazor(rpcParameters RPC.RPCParameters) (*big.Int, err
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1229,15 +1229,15 @@ func (_m *Utils) GetMinSafeRazor(rpcParameters RPC.RPCParameters) (*big.Int, err
 }
 
 // GetMinStakeAmount provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetMinStakeAmount(rpcParameters RPC.RPCParameters) (*big.Int, error) {
+func (_m *Utils) GetMinStakeAmount(rpcParameters rpc.RPCParameters) (*big.Int, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (*big.Int, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) *big.Int); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		if ret.Get(0) != nil {
@@ -1245,7 +1245,7 @@ func (_m *Utils) GetMinStakeAmount(rpcParameters RPC.RPCParameters) (*big.Int, e
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1255,21 +1255,21 @@ func (_m *Utils) GetMinStakeAmount(rpcParameters RPC.RPCParameters) (*big.Int, e
 }
 
 // GetNumActiveCollections provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetNumActiveCollections(rpcParameters RPC.RPCParameters) (uint16, error) {
+func (_m *Utils) GetNumActiveCollections(rpcParameters rpc.RPCParameters) (uint16, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint16, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint16); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1279,21 +1279,21 @@ func (_m *Utils) GetNumActiveCollections(rpcParameters RPC.RPCParameters) (uint1
 }
 
 // GetNumCollections provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetNumCollections(rpcParameters RPC.RPCParameters) (uint16, error) {
+func (_m *Utils) GetNumCollections(rpcParameters rpc.RPCParameters) (uint16, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint16, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint16); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1303,21 +1303,21 @@ func (_m *Utils) GetNumCollections(rpcParameters RPC.RPCParameters) (uint16, err
 }
 
 // GetNumJobs provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetNumJobs(rpcParameters RPC.RPCParameters) (uint16, error) {
+func (_m *Utils) GetNumJobs(rpcParameters rpc.RPCParameters) (uint16, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint16, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint16); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1327,21 +1327,21 @@ func (_m *Utils) GetNumJobs(rpcParameters RPC.RPCParameters) (uint16, error) {
 }
 
 // GetNumberOfProposedBlocks provides a mock function with given fields: rpcParameters, epoch
-func (_m *Utils) GetNumberOfProposedBlocks(rpcParameters RPC.RPCParameters, epoch uint32) (uint8, error) {
+func (_m *Utils) GetNumberOfProposedBlocks(rpcParameters rpc.RPCParameters, epoch uint32) (uint8, error) {
 	ret := _m.Called(rpcParameters, epoch)
 
 	var r0 uint8
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (uint8, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (uint8, error)); ok {
 		return rf(rpcParameters, epoch)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) uint8); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) uint8); ok {
 		r0 = rf(rpcParameters, epoch)
 	} else {
 		r0 = ret.Get(0).(uint8)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, epoch)
 	} else {
 		r1 = ret.Error(1)
@@ -1351,21 +1351,21 @@ func (_m *Utils) GetNumberOfProposedBlocks(rpcParameters RPC.RPCParameters, epoc
 }
 
 // GetNumberOfStakers provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetNumberOfStakers(rpcParameters RPC.RPCParameters) (uint32, error) {
+func (_m *Utils) GetNumberOfStakers(rpcParameters rpc.RPCParameters) (uint32, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint32, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint32); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1389,21 +1389,21 @@ func (_m *Utils) GetOptions() bind.CallOpts {
 }
 
 // GetProposedBlock provides a mock function with given fields: rpcParameters, epoch, proposedBlockId
-func (_m *Utils) GetProposedBlock(rpcParameters RPC.RPCParameters, epoch uint32, proposedBlockId uint32) (bindings.StructsBlock, error) {
+func (_m *Utils) GetProposedBlock(rpcParameters rpc.RPCParameters, epoch uint32, proposedBlockId uint32) (bindings.StructsBlock, error) {
 	ret := _m.Called(rpcParameters, epoch, proposedBlockId)
 
 	var r0 bindings.StructsBlock
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32) (bindings.StructsBlock, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32) (bindings.StructsBlock, error)); ok {
 		return rf(rpcParameters, epoch, proposedBlockId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32) bindings.StructsBlock); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32) bindings.StructsBlock); ok {
 		r0 = rf(rpcParameters, epoch, proposedBlockId)
 	} else {
 		r0 = ret.Get(0).(bindings.StructsBlock)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, uint32) error); ok {
 		r1 = rf(rpcParameters, epoch, proposedBlockId)
 	} else {
 		r1 = ret.Error(1)
@@ -1453,15 +1453,15 @@ func (_m *Utils) GetRogueRandomValue(value int) *big.Int {
 }
 
 // GetSaltFromBlockchain provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetSaltFromBlockchain(rpcParameters RPC.RPCParameters) ([32]byte, error) {
+func (_m *Utils) GetSaltFromBlockchain(rpcParameters rpc.RPCParameters) ([32]byte, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 [32]byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) ([32]byte, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) ([32]byte, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) [32]byte); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) [32]byte); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		if ret.Get(0) != nil {
@@ -1469,7 +1469,7 @@ func (_m *Utils) GetSaltFromBlockchain(rpcParameters RPC.RPCParameters) ([32]byt
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1479,21 +1479,21 @@ func (_m *Utils) GetSaltFromBlockchain(rpcParameters RPC.RPCParameters) ([32]byt
 }
 
 // GetSortedProposedBlockId provides a mock function with given fields: rpcParameters, epoch, index
-func (_m *Utils) GetSortedProposedBlockId(rpcParameters RPC.RPCParameters, epoch uint32, index *big.Int) (uint32, error) {
+func (_m *Utils) GetSortedProposedBlockId(rpcParameters rpc.RPCParameters, epoch uint32, index *big.Int) (uint32, error) {
 	ret := _m.Called(rpcParameters, epoch, index)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, *big.Int) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, *big.Int) (uint32, error)); ok {
 		return rf(rpcParameters, epoch, index)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, *big.Int) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, *big.Int) uint32); ok {
 		r0 = rf(rpcParameters, epoch, index)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, *big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, *big.Int) error); ok {
 		r1 = rf(rpcParameters, epoch, index)
 	} else {
 		r1 = ret.Error(1)
@@ -1503,15 +1503,15 @@ func (_m *Utils) GetSortedProposedBlockId(rpcParameters RPC.RPCParameters, epoch
 }
 
 // GetSortedProposedBlockIds provides a mock function with given fields: rpcParameters, epoch
-func (_m *Utils) GetSortedProposedBlockIds(rpcParameters RPC.RPCParameters, epoch uint32) ([]uint32, error) {
+func (_m *Utils) GetSortedProposedBlockIds(rpcParameters rpc.RPCParameters, epoch uint32) ([]uint32, error) {
 	ret := _m.Called(rpcParameters, epoch)
 
 	var r0 []uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) ([]uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) ([]uint32, error)); ok {
 		return rf(rpcParameters, epoch)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) []uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) []uint32); ok {
 		r0 = rf(rpcParameters, epoch)
 	} else {
 		if ret.Get(0) != nil {
@@ -1519,7 +1519,7 @@ func (_m *Utils) GetSortedProposedBlockIds(rpcParameters RPC.RPCParameters, epoc
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, epoch)
 	} else {
 		r1 = ret.Error(1)
@@ -1529,15 +1529,15 @@ func (_m *Utils) GetSortedProposedBlockIds(rpcParameters RPC.RPCParameters, epoc
 }
 
 // GetStake provides a mock function with given fields: rpcParameters, stakerId
-func (_m *Utils) GetStake(rpcParameters RPC.RPCParameters, stakerId uint32) (*big.Int, error) {
+func (_m *Utils) GetStake(rpcParameters rpc.RPCParameters, stakerId uint32) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, stakerId)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (*big.Int, error)); ok {
 		return rf(rpcParameters, stakerId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) *big.Int); ok {
 		r0 = rf(rpcParameters, stakerId)
 	} else {
 		if ret.Get(0) != nil {
@@ -1545,7 +1545,7 @@ func (_m *Utils) GetStake(rpcParameters RPC.RPCParameters, stakerId uint32) (*bi
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId)
 	} else {
 		r1 = ret.Error(1)
@@ -1597,15 +1597,15 @@ func (_m *Utils) GetStakeManagerWithOpts(client *ethclient.Client) (*bindings.St
 }
 
 // GetStakeSnapshot provides a mock function with given fields: rpcParameters, stakerId, epoch
-func (_m *Utils) GetStakeSnapshot(rpcParameters RPC.RPCParameters, stakerId uint32, epoch uint32) (*big.Int, error) {
+func (_m *Utils) GetStakeSnapshot(rpcParameters rpc.RPCParameters, stakerId uint32, epoch uint32) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, stakerId, epoch)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32) (*big.Int, error)); ok {
 		return rf(rpcParameters, stakerId, epoch)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32) *big.Int); ok {
 		r0 = rf(rpcParameters, stakerId, epoch)
 	} else {
 		if ret.Get(0) != nil {
@@ -1613,7 +1613,7 @@ func (_m *Utils) GetStakeSnapshot(rpcParameters RPC.RPCParameters, stakerId uint
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId, epoch)
 	} else {
 		r1 = ret.Error(1)
@@ -1665,21 +1665,21 @@ func (_m *Utils) GetStakedTokenManagerWithOpts(client *ethclient.Client, tokenAd
 }
 
 // GetStaker provides a mock function with given fields: rpcParameters, stakerId
-func (_m *Utils) GetStaker(rpcParameters RPC.RPCParameters, stakerId uint32) (bindings.StructsStaker, error) {
+func (_m *Utils) GetStaker(rpcParameters rpc.RPCParameters, stakerId uint32) (bindings.StructsStaker, error) {
 	ret := _m.Called(rpcParameters, stakerId)
 
 	var r0 bindings.StructsStaker
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (bindings.StructsStaker, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (bindings.StructsStaker, error)); ok {
 		return rf(rpcParameters, stakerId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) bindings.StructsStaker); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) bindings.StructsStaker); ok {
 		r0 = rf(rpcParameters, stakerId)
 	} else {
 		r0 = ret.Get(0).(bindings.StructsStaker)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId)
 	} else {
 		r1 = ret.Error(1)
@@ -1689,21 +1689,21 @@ func (_m *Utils) GetStaker(rpcParameters RPC.RPCParameters, stakerId uint32) (bi
 }
 
 // GetStakerId provides a mock function with given fields: rpcParameters, address
-func (_m *Utils) GetStakerId(rpcParameters RPC.RPCParameters, address string) (uint32, error) {
+func (_m *Utils) GetStakerId(rpcParameters rpc.RPCParameters, address string) (uint32, error) {
 	ret := _m.Called(rpcParameters, address)
 
 	var r0 uint32
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) (uint32, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) (uint32, error)); ok {
 		return rf(rpcParameters, address)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) uint32); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) uint32); ok {
 		r0 = rf(rpcParameters, address)
 	} else {
 		r0 = ret.Get(0).(uint32)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, string) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, string) error); ok {
 		r1 = rf(rpcParameters, address)
 	} else {
 		r1 = ret.Error(1)
@@ -1713,15 +1713,15 @@ func (_m *Utils) GetStakerId(rpcParameters RPC.RPCParameters, address string) (u
 }
 
 // GetStakerSRZRBalance provides a mock function with given fields: rpcParameters, staker
-func (_m *Utils) GetStakerSRZRBalance(rpcParameters RPC.RPCParameters, staker bindings.StructsStaker) (*big.Int, error) {
+func (_m *Utils) GetStakerSRZRBalance(rpcParameters rpc.RPCParameters, staker bindings.StructsStaker) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, staker)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, bindings.StructsStaker) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, bindings.StructsStaker) (*big.Int, error)); ok {
 		return rf(rpcParameters, staker)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, bindings.StructsStaker) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, bindings.StructsStaker) *big.Int); ok {
 		r0 = rf(rpcParameters, staker)
 	} else {
 		if ret.Get(0) != nil {
@@ -1729,7 +1729,7 @@ func (_m *Utils) GetStakerSRZRBalance(rpcParameters RPC.RPCParameters, staker bi
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, bindings.StructsStaker) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, bindings.StructsStaker) error); ok {
 		r1 = rf(rpcParameters, staker)
 	} else {
 		r1 = ret.Error(1)
@@ -1739,21 +1739,21 @@ func (_m *Utils) GetStakerSRZRBalance(rpcParameters RPC.RPCParameters, staker bi
 }
 
 // GetStateBuffer provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetStateBuffer(rpcParameters RPC.RPCParameters) (uint64, error) {
+func (_m *Utils) GetStateBuffer(rpcParameters rpc.RPCParameters) (uint64, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint64
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint64, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint64, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint64); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint64); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint64)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -1779,15 +1779,15 @@ func (_m *Utils) GetTokenManager(client *ethclient.Client) *bindings.RAZOR {
 }
 
 // GetTotalInfluenceRevealed provides a mock function with given fields: rpcParameters, epoch, medianIndex
-func (_m *Utils) GetTotalInfluenceRevealed(rpcParameters RPC.RPCParameters, epoch uint32, medianIndex uint16) (*big.Int, error) {
+func (_m *Utils) GetTotalInfluenceRevealed(rpcParameters rpc.RPCParameters, epoch uint32, medianIndex uint16) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, epoch, medianIndex)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint16) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint16) (*big.Int, error)); ok {
 		return rf(rpcParameters, epoch, medianIndex)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint16) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint16) *big.Int); ok {
 		r0 = rf(rpcParameters, epoch, medianIndex)
 	} else {
 		if ret.Get(0) != nil {
@@ -1795,7 +1795,7 @@ func (_m *Utils) GetTotalInfluenceRevealed(rpcParameters RPC.RPCParameters, epoc
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, uint16) error); ok {
 		r1 = rf(rpcParameters, epoch, medianIndex)
 	} else {
 		r1 = ret.Error(1)
@@ -1805,11 +1805,15 @@ func (_m *Utils) GetTotalInfluenceRevealed(rpcParameters RPC.RPCParameters, epoc
 }
 
 // GetTxnOpts provides a mock function with given fields: rpcParameters, transactionData
-func (_m *Utils) GetTxnOpts(rpcParameters RPC.RPCParameters, transactionData types.TransactionOptions) *bind.TransactOpts {
+func (_m *Utils) GetTxnOpts(rpcParameters rpc.RPCParameters, transactionData types.TransactionOptions) (*bind.TransactOpts, error) {
 	ret := _m.Called(rpcParameters, transactionData)
 
 	var r0 *bind.TransactOpts
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, types.TransactionOptions) *bind.TransactOpts); ok {
+	var r1 error
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, types.TransactionOptions) (*bind.TransactOpts, error)); ok {
+		return rf(rpcParameters, transactionData)
+	}
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, types.TransactionOptions) *bind.TransactOpts); ok {
 		r0 = rf(rpcParameters, transactionData)
 	} else {
 		if ret.Get(0) != nil {
@@ -1817,7 +1821,13 @@ func (_m *Utils) GetTxnOpts(rpcParameters RPC.RPCParameters, transactionData typ
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, types.TransactionOptions) error); ok {
+		r1 = rf(rpcParameters, transactionData)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetUint32 provides a mock function with given fields: flagSet, name
@@ -1887,15 +1897,15 @@ func (_m *Utils) GetVoteManagerWithOpts(client *ethclient.Client) (*bindings.Vot
 }
 
 // GetVoteValue provides a mock function with given fields: rpcParameters, epoch, stakerId, medianIndex
-func (_m *Utils) GetVoteValue(rpcParameters RPC.RPCParameters, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
+func (_m *Utils) GetVoteValue(rpcParameters rpc.RPCParameters, epoch uint32, stakerId uint32, medianIndex uint16) (*big.Int, error) {
 	ret := _m.Called(rpcParameters, epoch, stakerId, medianIndex)
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32, uint16) (*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32, uint16) (*big.Int, error)); ok {
 		return rf(rpcParameters, epoch, stakerId, medianIndex)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32, uint32, uint16) *big.Int); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32, uint32, uint16) *big.Int); ok {
 		r0 = rf(rpcParameters, epoch, stakerId, medianIndex)
 	} else {
 		if ret.Get(0) != nil {
@@ -1903,7 +1913,7 @@ func (_m *Utils) GetVoteValue(rpcParameters RPC.RPCParameters, epoch uint32, sta
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32, uint32, uint16) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32, uint32, uint16) error); ok {
 		r1 = rf(rpcParameters, epoch, stakerId, medianIndex)
 	} else {
 		r1 = ret.Error(1)
@@ -1913,21 +1923,21 @@ func (_m *Utils) GetVoteValue(rpcParameters RPC.RPCParameters, epoch uint32, sta
 }
 
 // GetWithdrawInitiationPeriod provides a mock function with given fields: rpcParameters
-func (_m *Utils) GetWithdrawInitiationPeriod(rpcParameters RPC.RPCParameters) (uint16, error) {
+func (_m *Utils) GetWithdrawInitiationPeriod(rpcParameters rpc.RPCParameters) (uint16, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint16, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint16); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -2079,21 +2089,21 @@ func (_m *Utils) SecondsToReadableTime(input int) string {
 }
 
 // StakerInfo provides a mock function with given fields: rpcParameters, stakerId
-func (_m *Utils) StakerInfo(rpcParameters RPC.RPCParameters, stakerId uint32) (types.Staker, error) {
+func (_m *Utils) StakerInfo(rpcParameters rpc.RPCParameters, stakerId uint32) (types.Staker, error) {
 	ret := _m.Called(rpcParameters, stakerId)
 
 	var r0 types.Staker
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) (types.Staker, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) (types.Staker, error)); ok {
 		return rf(rpcParameters, stakerId)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, uint32) types.Staker); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, uint32) types.Staker); ok {
 		r0 = rf(rpcParameters, stakerId)
 	} else {
 		r0 = ret.Get(0).(types.Staker)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters, uint32) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters, uint32) error); ok {
 		r1 = rf(rpcParameters, stakerId)
 	} else {
 		r1 = ret.Error(1)
@@ -2103,21 +2113,21 @@ func (_m *Utils) StakerInfo(rpcParameters RPC.RPCParameters, stakerId uint32) (t
 }
 
 // ToAssign provides a mock function with given fields: rpcParameters
-func (_m *Utils) ToAssign(rpcParameters RPC.RPCParameters) (uint16, error) {
+func (_m *Utils) ToAssign(rpcParameters rpc.RPCParameters) (uint16, error) {
 	ret := _m.Called(rpcParameters)
 
 	var r0 uint16
 	var r1 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) (uint16, error)); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) (uint16, error)); ok {
 		return rf(rpcParameters)
 	}
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters) uint16); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters) uint16); ok {
 		r0 = rf(rpcParameters)
 	} else {
 		r0 = ret.Get(0).(uint16)
 	}
 
-	if rf, ok := ret.Get(1).(func(RPC.RPCParameters) error); ok {
+	if rf, ok := ret.Get(1).(func(rpc.RPCParameters) error); ok {
 		r1 = rf(rpcParameters)
 	} else {
 		r1 = ret.Error(1)
@@ -2127,11 +2137,11 @@ func (_m *Utils) ToAssign(rpcParameters RPC.RPCParameters) (uint16, error) {
 }
 
 // WaitForBlockCompletion provides a mock function with given fields: rpcManager, hashToRead
-func (_m *Utils) WaitForBlockCompletion(rpcManager RPC.RPCParameters, hashToRead string) error {
+func (_m *Utils) WaitForBlockCompletion(rpcManager rpc.RPCParameters, hashToRead string) error {
 	ret := _m.Called(rpcManager, hashToRead)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, string) error); ok {
+	if rf, ok := ret.Get(0).(func(rpc.RPCParameters, string) error); ok {
 		r0 = rf(rpcManager, hashToRead)
 	} else {
 		r0 = ret.Error(0)

--- a/utils/options.go
+++ b/utils/options.go
@@ -32,7 +32,10 @@ func (*UtilsStruct) GetTxnOpts(rpcParameters rpc.RPCParameters, transactionData 
 		return nil, errors.New("account manager not initialised")
 	}
 	privateKey, err := account.AccountManager.GetPrivateKey(account.Address, account.Password)
-	CheckError("Error in fetching private key: ", err)
+	if err != nil {
+		log.Error("Error in fetching private key: ", err)
+		return nil, err
+	}
 
 	nonce, err := ClientInterface.GetNonceAtWithRetry(rpcParameters, common.HexToAddress(account.Address))
 	if err != nil {


### PR DESCRIPTION
# Description

This PR adds a additional return type `error` to `GetTxnOpts()` which would return error in any of the error case instead of existing fatal.  

Fixes https://linear.app/interstellar-research/issue/RAZ-1103

# How Has This Been Tested?

