### PR TITLE
feat: added state block check by introducing blockMonitor

### DIFF
--- a/RPC/rpc.go
+++ b/RPC/rpc.go
@@ -171,14 +171,14 @@ func (m *RPCManager) GetBestEndpointURL() (string, error) {
 
 // SwitchToNextBestRPCClient switches to the next best available client after the current best client.
 // If no valid next best client is found, it retains the current best client.
-func (m *RPCManager) SwitchToNextBestRPCClient() error {
+func (m *RPCManager) SwitchToNextBestRPCClient() (bool, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
 	// If there are fewer than 2 endpoints, there are no alternate clients to switch to.
 	if len(m.Endpoints) < 2 {
 		logrus.Warn("No alternate RPC clients available. Retaining the current best client.")
-		return nil
+		return false, nil
 	}
 
 	// Find the index of the current best client
@@ -192,7 +192,7 @@ func (m *RPCManager) SwitchToNextBestRPCClient() error {
 
 	// If the current client is not found (which is rare), return an error
 	if currentIndex == -1 {
-		return fmt.Errorf("current best client not found in the list of endpoints")
+		return false, fmt.Errorf("current best client not found in the list of endpoints")
 	}
 
 	// Iterate through the remaining endpoints to find a valid next best client
@@ -223,12 +223,12 @@ func (m *RPCManager) SwitchToNextBestRPCClient() error {
 
 		logrus.Infof("Switched to the next best RPC endpoint: %s (BlockNumber: %d, Latency: %.2f)",
 			m.BestEndpoint.URL, m.BestEndpoint.BlockNumber, m.BestEndpoint.Latency)
-		return nil
+		return true, nil
 	}
 
 	// If no valid endpoint is found, retain the current best client
 	logrus.Warn("No valid next-best RPC client found. Retaining the current best client.")
-	return nil
+	return false, nil
 }
 
 func (m *RPCManager) fetchBlockNumberWithTimeout(ctx context.Context, client *ethclient.Client) (uint64, error) {

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -7,20 +7,13 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"os"
-	"razor/block"
-	"razor/core/types"
 	"razor/logger"
 	"razor/path"
 	"strings"
 )
 
-var log = logger.NewLogger("", &ethclient.Client{}, "", types.Configurations{}, &block.BlockMonitor{})
-
-func UpdateAccountsLogger(updatedLogger *logger.Logger) {
-	log = updatedLogger
-}
+var log = logger.GetLogger()
 
 //This function takes path and password as input and returns new account
 func (am *AccountManager) CreateAccount(keystorePath string, password string) accounts.Account {

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -7,13 +7,20 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"os"
+	"razor/block"
+	"razor/core/types"
 	"razor/logger"
 	"razor/path"
 	"strings"
 )
 
-var log = logger.NewLogger()
+var log = logger.NewLogger("", &ethclient.Client{}, "", types.Configurations{}, &block.BlockMonitor{})
+
+func UpdateAccountsLogger(updatedLogger *logger.Logger) {
+	log = updatedLogger
+}
 
 //This function takes path and password as input and returns new account
 func (am *AccountManager) CreateAccount(keystorePath string, password string) accounts.Account {

--- a/block/block.go
+++ b/block/block.go
@@ -2,40 +2,117 @@ package block
 
 import (
 	"context"
-	"razor/core"
 	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/sirupsen/logrus"
+	"razor/RPC"
 )
 
-var latestBlock *types.Header
-var mu = sync.Mutex{}
-
-func GetLatestBlock() *types.Header {
-	mu.Lock()
-	defer mu.Unlock()
-	return latestBlock
+// BlockMonitor monitors the latest block and handles stale blocks.
+type BlockMonitor struct {
+	client             *ethclient.Client
+	rpcManager         *RPC.RPCManager
+	latestBlock        *types.Header
+	mu                 sync.Mutex
+	checkInterval      time.Duration
+	staleThreshold     time.Duration
+	staleBlockCallback func()
 }
 
-func SetLatestBlock(block *types.Header) {
-	mu.Lock()
-	latestBlock = block
-	mu.Unlock()
+// NewBlockMonitor initializes a BlockMonitor with RPC integration.
+func NewBlockMonitor(client *ethclient.Client, rpcManager *RPC.RPCManager, checkInterval, staleThreshold time.Duration, staleBlockCallback func()) *BlockMonitor {
+	return &BlockMonitor{
+		client:             client,
+		rpcManager:         rpcManager,
+		checkInterval:      time.Second * checkInterval,
+		staleThreshold:     time.Second * staleThreshold,
+		staleBlockCallback: staleBlockCallback,
+	}
 }
 
-func CalculateLatestBlock(client *ethclient.Client) {
-	for {
-		if client != nil {
-			latestHeader, err := client.HeaderByNumber(context.Background(), nil)
+// Start begins the block monitoring process.
+func (bm *BlockMonitor) Start() {
+	go func() {
+		for {
+			bm.updateLatestBlock()
+			bm.checkForStaleBlock()
+			time.Sleep(bm.checkInterval)
+		}
+	}()
+}
+
+// GetLatestBlock retrieves the most recent block header safely.
+func (bm *BlockMonitor) GetLatestBlock() *types.Header {
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+	return bm.latestBlock
+}
+
+// updateLatestBlock fetches the latest block and updates the state.
+func (bm *BlockMonitor) updateLatestBlock() {
+	if bm.client == nil {
+		return
+	}
+
+	header, err := bm.client.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		logrus.Errorf("Error fetching latest block: %v", err)
+		return
+	}
+
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+
+	// Update the latest block only if it changes.
+	if bm.latestBlock == nil || header.Number.Uint64() != bm.latestBlock.Number.Uint64() {
+		bm.latestBlock = header
+	}
+}
+
+// checkForStaleBlock detects stale blocks and triggers appropriate actions.
+func (bm *BlockMonitor) checkForStaleBlock() {
+	if bm.staleThreshold == 0 {
+		return
+	}
+
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+
+	if bm.latestBlock == nil || time.Since(time.Unix(int64(bm.latestBlock.Time), 0)) >= bm.staleThreshold {
+		logrus.Warnf("Stale block detected: Block %d is stale for %s", bm.latestBlock.Number.Uint64(), bm.staleThreshold)
+
+		// Switch to the next best RPC endpoint if stale block detected.
+		if bm.rpcManager != nil {
+			err := bm.rpcManager.SwitchToNextBestRPCClient()
 			if err != nil {
-				logrus.Error("CalculateBlockNumber: Error in fetching block: ", err)
+				logrus.Errorf("Failed to switch RPC endpoint: %v", err)
 			} else {
-				SetLatestBlock(latestHeader)
+				logrus.Info("Switched to the next best RPC endpoint.")
+				bm.updateClient()
 			}
 		}
-		time.Sleep(time.Second * time.Duration(core.BlockNumberInterval))
+
+		// Trigger the stale block callback if provided.
+		if bm.staleBlockCallback != nil {
+			bm.staleBlockCallback()
+		}
 	}
+}
+
+// updateClient updates the Ethereum client to use the new best RPC endpoint.
+func (bm *BlockMonitor) updateClient() {
+	if bm.rpcManager == nil {
+		return
+	}
+
+	newClient, err := bm.rpcManager.GetBestRPCClient()
+	if err != nil {
+		return
+	}
+
+	bm.client = newClient
+	logrus.Info("Client in logger updated with the new best RPC endpoint.")
 }

--- a/cmd/addStake_test.go
+++ b/cmd/addStake_test.go
@@ -318,7 +318,7 @@ func TestExecuteStake(t *testing.T) {
 			setupTestEndpointsEnvironment()
 
 			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
-			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything).Return("", nil)
+			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.password)
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)

--- a/cmd/addStake_test.go
+++ b/cmd/addStake_test.go
@@ -308,23 +308,23 @@ func TestExecuteStake(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
-			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
+			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything).Return("", nil)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.password)
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)
 			utilsMock.On("AccountManagerForKeystore").Return(&accounts.AccountManager{}, nil)
 			flagSetMock.On("GetStringAddress", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.address, tt.args.addressErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 			utilsMock.On("FetchBalance", mock.Anything, mock.Anything).Return(tt.args.balance, tt.args.balanceErr)
 			cmdUtilsMock.On("AssignAmountInWei", flagSet).Return(tt.args.amount, tt.args.amountErr)

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -68,6 +68,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 			args: args{
 				config:         types.Configurations{},
 				password:       "test",
+				isFlagPassed:   true,
 				addressErr:     errors.New("address error"),
 				bountyId:       2,
 				claimBountyTxn: common.BigToHash(big.NewInt(1)),
@@ -112,16 +113,16 @@ func TestExecuteClaimBounty(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
-			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
+			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything).Return("", nil)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.password)
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)
@@ -129,7 +130,6 @@ func TestExecuteClaimBounty(t *testing.T) {
 			flagSetMock.On("GetStringAddress", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.address, tt.args.addressErr)
 			flagSetMock.On("GetUint32BountyId", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.bountyId, tt.args.bountyIdErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("IsFlagPassed", mock.Anything).Return(tt.args.isFlagPassed)
 			cmdUtilsMock.On("HandleClaimBounty", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.handleClaimBountyErr)
 			cmdUtilsMock.On("ClaimBounty", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.claimBountyTxn, tt.args.claimBountyErr)

--- a/cmd/claimBounty_test.go
+++ b/cmd/claimBounty_test.go
@@ -122,7 +122,7 @@ func TestExecuteClaimBounty(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
-			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything).Return("", nil)
+			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.password)
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)

--- a/cmd/claimCommission_test.go
+++ b/cmd/claimCommission_test.go
@@ -189,16 +189,16 @@ func TestClaimCommission(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
-			fatal = false
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			utilsMock.On("GetStakerId", mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			utilsMock.On("GetOptions").Return(callOpts)
@@ -206,7 +206,6 @@ func TestClaimCommission(t *testing.T) {
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)
 			utilsMock.On("AccountManagerForKeystore").Return(&accounts.AccountManager{}, nil)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("GetTxnOpts", mock.Anything, mock.Anything).Return(TxnOpts)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 
@@ -218,6 +217,8 @@ func TestClaimCommission(t *testing.T) {
 			transactionMock.On("Hash", mock.Anything).Return(tt.args.hash)
 
 			utils := &UtilsStruct{}
+			fatal = false
+
 			utils.ClaimCommission(flagSet)
 			if fatal != tt.expectedFatal {
 				t.Error("The executeClaimBounty function didn't execute as expected")

--- a/cmd/cmd-utils.go
+++ b/cmd/cmd-utils.go
@@ -188,9 +188,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 	}
 
 	// Initialize BlockMonitor with RPCManager
-	blockMonitor = block.NewBlockMonitor(client, rpcManager, core.BlockNumberInterval, core.StaleBlockNumberCheckInterval, func() {
-		log.Warn("STALE BLOCK DETECTED! Attempting to move to next best RPC client...")
-	})
+	blockMonitor = block.NewBlockMonitor(client, rpcManager, core.BlockNumberInterval, core.StaleBlockNumberCheckInterval)
 	blockMonitor.Start()
 	log.Debug("Checking to assign log file...")
 	fileUtils.AssignLogFile(flagSet, config)

--- a/cmd/cmd-utils.go
+++ b/cmd/cmd-utils.go
@@ -189,7 +189,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 
 	// Initialize BlockMonitor with RPCManager
 	blockMonitor = block.NewBlockMonitor(client, rpcManager, core.BlockNumberInterval, core.StaleBlockNumberCheckInterval, func() {
-		log.Warn("Custom action on stale block detected.")
+		log.Warn("STALE BLOCK DETECTED! Attempting to move to next best RPC client...")
 	})
 	blockMonitor.Start()
 	log.Debug("Checking to assign log file...")

--- a/cmd/collectionList.go
+++ b/cmd/collectionList.go
@@ -2,11 +2,9 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 	"razor/RPC"
-	"razor/logger"
 	"razor/utils"
 	"strconv"
 	"strings"
@@ -33,20 +31,8 @@ func initialiseCollectionList(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and and executes the GetCollectionList function
 func (*UtilsStruct) ExecuteCollectionList(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-	log.Debugf("ExecuteCollectionList: Config: %+v", config)
-
-	client := razorUtils.ConnectToClient(config.Provider)
-	logger.SetLoggerParameters(client, "")
-
-	rpcManager, err := RPC.InitializeRPCManager(config.Provider)
-	utils.CheckError("Error in initializing RPC Manager: ", err)
-
-	rpcParameters := RPC.RPCParameters{
-		RPCManager: rpcManager,
-		Ctx:        context.Background(),
-	}
+	_, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	log.Debug("Calling GetCollectionList()")
 	err = cmdUtils.GetCollectionList(rpcParameters)

--- a/cmd/collectionList_test.go
+++ b/cmd/collectionList_test.go
@@ -129,19 +129,19 @@ func TestExecuteCollectionList(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("GetCollectionList", mock.Anything).Return(tt.args.collectionListErr)
 
 			utils := &UtilsStruct{}

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -6,6 +6,7 @@ import (
 	"razor/RPC"
 	"razor/core"
 	"razor/core/types"
+	"razor/logger"
 	"razor/utils"
 	"strings"
 
@@ -97,7 +98,7 @@ func (*UtilsStruct) GetConfigData() (types.Configurations, error) {
 	config.LogFileMaxBackups = logFileMaxBackups
 	config.LogFileMaxAge = logFileMaxAge
 
-	setLogLevel(config)
+	setLogLevel(log, config)
 
 	return config, nil
 }
@@ -369,18 +370,22 @@ func (*UtilsStruct) GetLogFileMaxAge() (int, error) {
 	return logFileMaxAge.(int), nil
 }
 
-//This function sets the log level
-func setLogLevel(config types.Configurations) {
+// setLogLevel sets the log level for the provided logger instance.
+func setLogLevel(logger *logger.Logger, config types.Configurations) {
+	// Set the log level based on the configuration
 	if config.LogLevel == "debug" {
-		log.SetLevel(logrus.DebugLevel)
+		logger.SetLogLevel(logrus.DebugLevel)
+		logger.Debug("Log level set to DEBUG")
 	}
 
-	log.Debugf("Config details: %+v", config)
+	// Log configuration details if debug level is enabled
+	logger.Debugf("Config details: %+v", config)
 
+	// Log additional details if the log file flag is passed
 	if razorUtils.IsFlagPassed("logFile") {
-		log.Debugf("Log File Max Size: %d MB", config.LogFileMaxSize)
-		log.Debugf("Log File Max Backups (max number of old log files to retain): %d", config.LogFileMaxBackups)
-		log.Debugf("Log File Max Age (max number of days to retain old log files): %d", config.LogFileMaxAge)
+		logger.Debugf("Log File Max Size: %d MB", config.LogFileMaxSize)
+		logger.Debugf("Log File Max Backups (max number of old log files to retain): %d", config.LogFileMaxBackups)
+		logger.Debugf("Log File Max Age (max number of days to retain old log files): %d", config.LogFileMaxAge)
 	}
 }
 

--- a/cmd/config-utils.go
+++ b/cmd/config-utils.go
@@ -6,7 +6,6 @@ import (
 	"razor/RPC"
 	"razor/core"
 	"razor/core/types"
-	"razor/logger"
 	"razor/utils"
 	"strings"
 
@@ -98,7 +97,7 @@ func (*UtilsStruct) GetConfigData() (types.Configurations, error) {
 	config.LogFileMaxBackups = logFileMaxBackups
 	config.LogFileMaxAge = logFileMaxAge
 
-	setLogLevel(log, config)
+	setLogLevel(config)
 
 	return config, nil
 }
@@ -370,22 +369,18 @@ func (*UtilsStruct) GetLogFileMaxAge() (int, error) {
 	return logFileMaxAge.(int), nil
 }
 
-// setLogLevel sets the log level for the provided logger instance.
-func setLogLevel(logger *logger.Logger, config types.Configurations) {
-	// Set the log level based on the configuration
+//This function sets the log level
+func setLogLevel(config types.Configurations) {
 	if config.LogLevel == "debug" {
-		logger.SetLogLevel(logrus.DebugLevel)
-		logger.Debug("Log level set to DEBUG")
+		log.SetLogLevel(logrus.DebugLevel)
 	}
 
-	// Log configuration details if debug level is enabled
-	logger.Debugf("Config details: %+v", config)
+	log.Debugf("Config details: %+v", config)
 
-	// Log additional details if the log file flag is passed
 	if razorUtils.IsFlagPassed("logFile") {
-		logger.Debugf("Log File Max Size: %d MB", config.LogFileMaxSize)
-		logger.Debugf("Log File Max Backups (max number of old log files to retain): %d", config.LogFileMaxBackups)
-		logger.Debugf("Log File Max Age (max number of days to retain old log files): %d", config.LogFileMaxAge)
+		log.Debugf("Log File Max Size: %d MB", config.LogFileMaxSize)
+		log.Debugf("Log File Max Backups (max number of old log files to retain): %d", config.LogFileMaxBackups)
+		log.Debugf("Log File Max Age (max number of days to retain old log files): %d", config.LogFileMaxAge)
 	}
 }
 

--- a/cmd/contractAddresses.go
+++ b/cmd/contractAddresses.go
@@ -25,10 +25,9 @@ func initialiseContractAddresses(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriatley and executes the ContractAddresses function
 func (*UtilsStruct) ExecuteContractAddresses(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-	log.Debug("Checking to assign log file...")
-	fileUtils.AssignLogFile(flagSet, config)
+	_, _, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
+
 	fmt.Println("The contract addresses are: ")
 	cmdUtils.ContractAddresses()
 

--- a/cmd/contractAddresses_test.go
+++ b/cmd/contractAddresses_test.go
@@ -35,13 +35,15 @@ func TestExecuteContractAddresses(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
+			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(types.Configurations{}, nil)
 			cmdUtilsMock.On("ContractAddresses")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -28,10 +28,8 @@ func initialiseCreate(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the Create function
 func (*UtilsStruct) ExecuteCreate(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-	log.Debug("Checking to assign log file...")
-	fileUtils.AssignLogFile(flagSet, config)
+	_, _, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 	log.Info("The password should be of minimum 8 characters containing least 1 uppercase, lowercase, digit and special character.")
 	password := razorUtils.AssignPassword(flagSet)
 	log.Debug("ExecuteCreate: Calling Create() with argument as input password")

--- a/cmd/createCollection_test.go
+++ b/cmd/createCollection_test.go
@@ -264,15 +264,16 @@ func TestExecuteCreateCollection(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -285,7 +286,6 @@ func TestExecuteCreateCollection(t *testing.T) {
 			flagSetMock.On("GetInt8Power", flagSet).Return(tt.args.power, tt.args.powerErr)
 			flagSetMock.On("GetUint32Tolerance", flagSet).Return(tt.args.tolerance, tt.args.toleranceErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("CreateCollection", mock.Anything, config, mock.Anything).Return(tt.args.createCollectionHash, tt.args.createCollectionErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 

--- a/cmd/createJob_test.go
+++ b/cmd/createJob_test.go
@@ -286,15 +286,16 @@ func TestExecuteCreateJob(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -308,7 +309,6 @@ func TestExecuteCreateJob(t *testing.T) {
 			flagSetMock.On("GetUint8Weight", flagSet).Return(tt.args.weight, tt.args.weightErr)
 			flagSetMock.On("GetUint8SelectorType", flagSet).Return(tt.args.selectorType, tt.args.selectorTypeErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("CreateJob", mock.Anything, config, mock.Anything).Return(tt.args.createJobHash, tt.args.createJobErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -148,14 +148,16 @@ func TestExecuteCreate(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
+			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			utilsMock.On("AssignPassword", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.password)
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)

--- a/cmd/delegate_test.go
+++ b/cmd/delegate_test.go
@@ -104,9 +104,9 @@ func TestExecuteDelegate(t *testing.T) {
 		delegateErr  error
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	tests := []struct {
 		name          string
@@ -238,6 +238,7 @@ func TestExecuteDelegate(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -246,7 +247,6 @@ func TestExecuteDelegate(t *testing.T) {
 			flagSetMock.On("GetStringAddress", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.address, tt.args.addressErr)
 			flagSetMock.On("GetUint32StakerId", flagSet).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 			utilsMock.On("FetchBalance", mock.Anything, mock.Anything).Return(tt.args.balance, tt.args.balanceErr)
 			cmdUtilsMock.On("AssignAmountInWei", flagSet).Return(tt.args.amount, tt.args.amountErr)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -29,10 +29,8 @@ func initialiseImport(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the ImportAccount function
 func (*UtilsStruct) ExecuteImport(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-	log.Debug("Checking to assign log file...")
-	fileUtils.AssignLogFile(flagSet, config)
+	_, _, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 	log.Debug("Calling ImportAccount()...")
 	account, err := cmdUtils.ImportAccount()
 	utils.CheckError("Import error: ", err)

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -208,14 +208,16 @@ func TestExecuteImport(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
+			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("ImportAccount").Return(tt.args.account, tt.args.accountErr)
 			cmdUtilsMock.On("GetConfigData").Return(types.Configurations{}, nil)

--- a/cmd/initTestMocks_test.go
+++ b/cmd/initTestMocks_test.go
@@ -266,18 +266,18 @@ func (d *DummyRPC) SlowMethod(client *ethclient.Client) error {
 	return nil
 }
 
-var testDir = "/tmp/test_rzr"
-
 func setupTestEndpointsEnvironment() {
+	var testDir = "/tmp/test_rzr"
+	pathMock.On("GetDefaultPath").Return(testDir, nil)
 	err := os.MkdirAll(testDir, 0755)
 	if err != nil {
-		log.Fatalf("failed to create test directory: %w", err)
+		log.Fatalf("failed to create test directory: %s", err.Error())
 	}
 
 	mockEndpoints := `["https://testnet.skalenodes.com/v1/juicy-low-small-testnet"]`
 	mockFilePath := filepath.Join(testDir, "endpoints.json")
 	err = os.WriteFile(mockFilePath, []byte(mockEndpoints), 0644)
 	if err != nil {
-		log.Fatalf("failed to write mock endpoints.json: %w", err)
+		log.Fatalf("failed to write mock endpoints.json: %s", err.Error())
 	}
 }

--- a/cmd/initiateWithdraw_test.go
+++ b/cmd/initiateWithdraw_test.go
@@ -351,15 +351,16 @@ func TestExecuteWithdraw(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -368,7 +369,6 @@ func TestExecuteWithdraw(t *testing.T) {
 			flagSetMock.On("GetStringAddress", flagSet).Return(tt.args.address, tt.args.addressErr)
 			utilsMock.On("AssignStakerId", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("HandleUnstakeLock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.withdrawHash, tt.args.withdrawErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 

--- a/cmd/jobList.go
+++ b/cmd/jobList.go
@@ -2,13 +2,11 @@
 package cmd
 
 import (
-	"context"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"os"
 	"razor/RPC"
-	"razor/logger"
 	"razor/utils"
 	"strconv"
 )
@@ -31,20 +29,8 @@ func initialiseJobList(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the GetJobList function
 func (*UtilsStruct) ExecuteJobList(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-	log.Debugf("ExecuteJobList: Config: %+v", config)
-
-	client := razorUtils.ConnectToClient(config.Provider)
-	logger.SetLoggerParameters(client, "")
-
-	rpcManager, err := RPC.InitializeRPCManager(config.Provider)
-	utils.CheckError("Error in initializing RPC Manager: ", err)
-
-	rpcParameters := RPC.RPCParameters{
-		RPCManager: rpcManager,
-		Ctx:        context.Background(),
-	}
+	_, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	log.Debug("ExecuteJobList: Calling JobList()...")
 	err = cmdUtils.GetJobList(rpcParameters)

--- a/cmd/jobList_test.go
+++ b/cmd/jobList_test.go
@@ -123,19 +123,19 @@ func TestExecuteJobList(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("GetJobList", mock.Anything).Return(tt.args.jobListErr)
 
 			utils := &UtilsStruct{}

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -26,11 +26,8 @@ func initialiseListAccounts(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the ListAccounts function
 func (*UtilsStruct) ExecuteListAccounts(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-
-	log.Debug("Checking to assign log file...")
-	fileUtils.AssignLogFile(flagSet, config)
+	_, _, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	log.Debug("ExecuteListAccounts: Calling ListAccounts()...")
 	allAccounts, err := cmdUtils.ListAccounts()

--- a/cmd/listAccounts.go
+++ b/cmd/listAccounts.go
@@ -26,9 +26,6 @@ func initialiseListAccounts(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the ListAccounts function
 func (*UtilsStruct) ExecuteListAccounts(flagSet *pflag.FlagSet) {
-	_, _, _, err := InitializeCommandDependencies(flagSet)
-	utils.CheckError("Error in initialising command dependencies: ", err)
-
 	log.Debug("ExecuteListAccounts: Calling ListAccounts()...")
 	allAccounts, err := cmdUtils.ListAccounts()
 	utils.CheckError("ListAccounts error: ", err)

--- a/cmd/listAccounts_test.go
+++ b/cmd/listAccounts_test.go
@@ -119,9 +119,9 @@ func TestExecuteListAccounts(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()

--- a/cmd/modifyCollectionStatus_test.go
+++ b/cmd/modifyCollectionStatus_test.go
@@ -245,15 +245,16 @@ func TestExecuteModifyAssetStatus(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			flagSetMock.On("GetStringAddress", flagSet).Return(tt.args.address, tt.args.addressErr)
@@ -264,7 +265,6 @@ func TestExecuteModifyAssetStatus(t *testing.T) {
 			utilsMock.On("AccountManagerForKeystore").Return(&accounts.AccountManager{}, nil)
 			stringMock.On("ParseBool", mock.AnythingOfType("string")).Return(tt.args.parseStatus, tt.args.parseStatusErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("ModifyCollectionStatus", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.ModifyCollectionStatusHash, tt.args.ModifyCollectionStatusErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 

--- a/cmd/resetUnstakeLock_test.go
+++ b/cmd/resetUnstakeLock_test.go
@@ -161,15 +161,16 @@ func TestExecuteExtendLock(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -178,7 +179,6 @@ func TestExecuteExtendLock(t *testing.T) {
 			flagSetMock.On("GetStringAddress", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.address, tt.args.addressErr)
 			utilsMock.On("AssignStakerId", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 			cmdUtilsMock.On("ResetUnstakeLock", mock.Anything, config, mock.Anything).Return(tt.args.resetLockTxn, tt.args.resetLockErr)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,11 +3,8 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"os"
-	"razor/block"
 	"razor/core"
-	"razor/core/types"
 	"razor/logger"
 	"razor/path"
 
@@ -32,11 +29,7 @@ var (
 	LogFileMaxAge      int
 )
 
-var log = logger.NewLogger("", &ethclient.Client{}, "", types.Configurations{}, &block.BlockMonitor{})
-
-func UpdateCmdLogger(updatedLogger *logger.Logger) {
-	log = updatedLogger
-}
+var log = logger.GetLogger()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,11 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"os"
+	"razor/block"
 	"razor/core"
+	"razor/core/types"
 	"razor/logger"
 	"razor/path"
 
@@ -29,7 +32,11 @@ var (
 	LogFileMaxAge      int
 )
 
-var log = logger.NewLogger()
+var log = logger.NewLogger("", &ethclient.Client{}, "", types.Configurations{}, &block.BlockMonitor{})
+
+func UpdateCmdLogger(updatedLogger *logger.Logger) {
+	log = updatedLogger
+}
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/setConfig.go
+++ b/cmd/setConfig.go
@@ -29,8 +29,8 @@ Example:
 
 // This function returns the error if there is any and sets the config
 func (*UtilsStruct) SetConfig(flagSet *pflag.FlagSet) error {
-	log.Debug("Checking to assign log file...")
-	fileUtils.AssignLogFile(flagSet, types.Configurations{})
+	_, _, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	flagDetails := []types.FlagDetail{
 		{Name: "provider", Type: "string"},

--- a/cmd/setConfig_test.go
+++ b/cmd/setConfig_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"razor/core/types"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -74,7 +75,10 @@ func TestSetConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
+			setupTestEndpointsEnvironment()
 
+			cmdUtilsMock.On("GetConfigData").Return(types.Configurations{}, nil)
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			flagSetMock.On("FetchFlagInput", flagSet, mock.Anything, mock.Anything).Return(tt.args.flagInput, tt.args.flagInputErr)
 			flagSetMock.On("Changed", mock.Anything, mock.Anything).Return(tt.args.isFlagPassed)

--- a/cmd/setDelegation_test.go
+++ b/cmd/setDelegation_test.go
@@ -369,9 +369,9 @@ func TestExecuteSetDelegation(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -379,6 +379,7 @@ func TestExecuteSetDelegation(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -389,7 +390,6 @@ func TestExecuteSetDelegation(t *testing.T) {
 			flagSetMock.On("GetUint8Commission", flagSet).Return(tt.args.commission, tt.args.commissionErr)
 			stringMock.On("ParseBool", mock.AnythingOfType("string")).Return(tt.args.parseStatus, tt.args.parseStatusErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("GetStakerId", mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			cmdUtilsMock.On("SetDelegation", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.setDelegationHash, tt.args.setDelegationErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)

--- a/cmd/stakerInfo.go
+++ b/cmd/stakerInfo.go
@@ -2,13 +2,11 @@
 package cmd
 
 import (
-	"context"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"os"
 	"razor/RPC"
-	"razor/logger"
 	"razor/utils"
 	"strconv"
 )
@@ -30,24 +28,12 @@ func initialiseStakerInfo(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the GetStakerInfo function
 func (*UtilsStruct) ExecuteStakerinfo(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-	log.Debugf("ExecuteStakerinfo: Config: %+v", config)
-
-	client := razorUtils.ConnectToClient(config.Provider)
-	logger.SetLoggerParameters(client, "")
+	_, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	stakerId, err := flagSetUtils.GetUint32StakerId(flagSet)
 	utils.CheckError("Error in getting stakerId: ", err)
 	log.Debug("ExecuteStakerinfo: StakerId: ", stakerId)
-
-	rpcManager, err := RPC.InitializeRPCManager(config.Provider)
-	utils.CheckError("Error in initializing RPC Manager: ", err)
-
-	rpcParameters := RPC.RPCParameters{
-		RPCManager: rpcManager,
-		Ctx:        context.Background(),
-	}
 
 	log.Debug("ExecuteStakerinfo: Calling GetStakerInfo() with argument stakerId = ", stakerId)
 	err = cmdUtils.GetStakerInfo(rpcParameters, stakerId)

--- a/cmd/stakerInfo_test.go
+++ b/cmd/stakerInfo_test.go
@@ -288,19 +288,19 @@ func TestUtilsStruct_ExecuteStakerinfo(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			flagSetMock.On("GetUint32StakerId", flagSet).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			cmdUtilsMock.On("GetStakerInfo", mock.Anything, mock.Anything).Return(tt.args.stakerInfoErr)
 

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -2,12 +2,10 @@
 package cmd
 
 import (
-	"context"
 	"razor/RPC"
 	"razor/accounts"
 	"razor/core"
 	"razor/core/types"
-	"razor/logger"
 	"razor/pkg/bindings"
 	"razor/utils"
 
@@ -34,19 +32,13 @@ func initialiseTransfer(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the Transfer function
 func (*UtilsStruct) ExecuteTransfer(flagSet *pflag.FlagSet) {
-	config, err := cmdUtils.GetConfigData()
-	utils.CheckError("Error in getting config: ", err)
-	log.Debugf("ExecuteTransfer: Config: %+v", config)
+	config, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	utils.CheckError("Error in initialising command dependencies: ", err)
 
-	client := razorUtils.ConnectToClient(config.Provider)
+	log.Debugf("ExecuteTransfer: Config: %+v", config)
 
 	fromAddress, err := flagSetUtils.GetStringFrom(flagSet)
 	utils.CheckError("Error in getting fromAddress: ", err)
-
-	logger.SetLoggerParameters(client, fromAddress)
-
-	log.Debug("Checking to assign log file...")
-	fileUtils.AssignLogFile(flagSet, config)
 
 	log.Debug("Getting password...")
 	password := razorUtils.AssignPassword(flagSet)
@@ -61,14 +53,6 @@ func (*UtilsStruct) ExecuteTransfer(flagSet *pflag.FlagSet) {
 
 	toAddress, err := flagSetUtils.GetStringTo(flagSet)
 	utils.CheckError("Error in getting toAddress: ", err)
-
-	rpcManager, err := RPC.InitializeRPCManager(config.Provider)
-	utils.CheckError("Error in initializing RPC Manager: ", err)
-
-	rpcParameters := RPC.RPCParameters{
-		RPCManager: rpcManager,
-		Ctx:        context.Background(),
-	}
 
 	balance, err := razorUtils.FetchBalance(rpcParameters, account.Address)
 	utils.CheckError("Error in fetching razor balance: ", err)

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -234,15 +234,16 @@ func TestExecuteTransfer(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(false)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -252,7 +253,6 @@ func TestExecuteTransfer(t *testing.T) {
 			flagSetMock.On("GetStringTo", flagSet).Return(tt.args.to, tt.args.toErr)
 			cmdUtilsMock.On("AssignAmountInWei", flagSet).Return(tt.args.amount, tt.args.amountErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("FetchBalance", mock.Anything, mock.Anything).Return(tt.args.balance, tt.args.balanceErr)
 			cmdUtilsMock.On("Transfer", mock.Anything, config, mock.Anything).Return(tt.args.transferHash, tt.args.transferErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)

--- a/cmd/unlockWithdraw_test.go
+++ b/cmd/unlockWithdraw_test.go
@@ -86,22 +86,22 @@ func TestExecuteUnlockWithdraw(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			flagSetMock.On("GetStringAddress", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.address, tt.args.addressErr)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
 			utilsMock.On("CheckPassword", mock.Anything).Return(nil)
 			utilsMock.On("AccountManagerForKeystore").Return(&accounts.AccountManager{}, nil)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
 			utilsMock.On("AssignStakerId", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			cmdUtilsMock.On("HandleWithdrawLock", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.txn, tt.args.err)

--- a/cmd/unstake_test.go
+++ b/cmd/unstake_test.go
@@ -282,15 +282,16 @@ func TestExecuteUnstake(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -298,7 +299,6 @@ func TestExecuteUnstake(t *testing.T) {
 			utilsMock.On("AccountManagerForKeystore").Return(&accounts.AccountManager{}, nil)
 			flagSetMock.On("GetStringAddress", flagSet).Return(tt.args.address, tt.args.addressErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("AssignAmountInWei", flagSet).Return(tt.args.value, tt.args.valueErr)
 			utilsMock.On("AssignStakerId", mock.Anything, flagSet, mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			utilsMock.On("GetLock", mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("uint32")).Return(tt.args.lock, tt.args.lockErr)

--- a/cmd/updateCollection_test.go
+++ b/cmd/updateCollection_test.go
@@ -265,15 +265,16 @@ func TestExecuteUpdateCollection(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -285,7 +286,6 @@ func TestExecuteUpdateCollection(t *testing.T) {
 			flagSetMock.On("GetUint32Aggregation", flagSet).Return(tt.args.aggregation, tt.args.aggregationErr)
 			flagSetMock.On("GetInt8Power", flagSet).Return(tt.args.power, tt.args.powerErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("UpdateCollection", mock.Anything, config, mock.Anything, mock.Anything).Return(tt.args.updateCollectionTxn, tt.args.updateCollectionErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 			flagSetMock.On("GetUint32Tolerance", flagSet).Return(tt.args.tolerance, tt.args.toleranceErr)

--- a/cmd/updateCommission_test.go
+++ b/cmd/updateCommission_test.go
@@ -322,15 +322,16 @@ func TestExecuteUpdateCommission(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			flagSetMock.On("GetStringAddress", flagSet).Return(tt.args.address, tt.args.addressErr)
@@ -340,7 +341,6 @@ func TestExecuteUpdateCommission(t *testing.T) {
 			flagSetMock.On("GetUint8Commission", flagSet).Return(tt.args.commission, tt.args.commissionErr)
 			utilsMock.On("GetStakerId", mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("UpdateCommission", mock.Anything, mock.Anything, mock.Anything).Return(tt.args.UpdateCommissionErr)
 
 			utils := &UtilsStruct{}

--- a/cmd/updateJob_test.go
+++ b/cmd/updateJob_test.go
@@ -311,15 +311,16 @@ func TestExecuteUpdateJob(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("AssignPassword", flagSet).Return(tt.args.password)
@@ -333,7 +334,6 @@ func TestExecuteUpdateJob(t *testing.T) {
 			flagSetMock.On("GetUint8Weight", flagSet).Return(tt.args.weight, tt.args.weightErr)
 			flagSetMock.On("GetUint8SelectorType", flagSet).Return(tt.args.selectorType, tt.args.selectorTypeErr)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			cmdUtilsMock.On("UpdateJob", mock.Anything, config, mock.Anything, mock.Anything).Return(tt.args.updateJobTxn, tt.args.updateJobErr)
 			utilsMock.On("WaitForBlockCompletion", mock.Anything, mock.Anything).Return(nil)
 

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -342,6 +342,13 @@ func (*UtilsStruct) HandleBlock(rpcParameters RPC.RPCParameters, account types.A
 					log.Error("Error in refreshing RPC endpoints: ", err)
 					break
 				}
+				bestEndpointURL, err := rpcParameters.RPCManager.GetBestEndpointURL()
+				if err != nil {
+					log.Error("Error in getting best RPC endpoint URL after refreshing: ", err)
+					break
+				}
+				log.Info("Current best RPC endpoint URL: ", bestEndpointURL)
+
 				lastRPCRefreshEpoch = epoch
 			}
 		}

--- a/cmd/vote_test.go
+++ b/cmd/vote_test.go
@@ -152,15 +152,16 @@ func TestExecuteVote(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			SetUpMockInterfaces()
 			setupTestEndpointsEnvironment()
 
+			utilsMock.On("IsFlagPassed", mock.Anything).Return(true)
 			fileUtilsMock.On("AssignLogFile", mock.AnythingOfType("*pflag.FlagSet"), mock.Anything)
 			cmdUtilsMock.On("GetConfigData").Return(tt.args.config, tt.args.configErr)
 			utilsMock.On("GetStateBuffer", mock.Anything).Return(uint64(5), nil)
@@ -170,7 +171,6 @@ func TestExecuteVote(t *testing.T) {
 			flagSetMock.On("GetStringAddress", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.address, tt.args.addressErr)
 			flagSetMock.On("GetStringSliceBackupNode", mock.Anything).Return([]string{}, nil)
 			utilsMock.On("ConnectToClient", mock.AnythingOfType("string")).Return(client)
-			pathMock.On("GetDefaultPath").Return(testDir, nil)
 			flagSetMock.On("GetBoolRogue", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.rogueStatus, tt.args.rogueErr)
 			utilsMock.On("GetStakerId", mock.Anything, mock.Anything).Return(tt.args.stakerId, tt.args.stakerIdErr)
 			flagSetMock.On("GetStringSliceRogueMode", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.rogueMode, tt.args.rogueModeErr)

--- a/core/constants.go
+++ b/core/constants.go
@@ -69,11 +69,17 @@ const (
 	DefaultPathName   = ".razor"
 )
 
-//BlockNumberInterval is the interval in seconds after which blockNumber needs to be calculated again
 const (
-	BlockNumberInterval           = 5
+	//BlockNumberInterval is the interval in seconds after which blockNumber needs to be calculated again by blockMonitor
+	BlockNumberInterval = 5
+
+	// StaleBlockNumberCheckInterval specifies the duration in seconds after which the BlockMonitor
+	// switches to an alternate endpoint if the block number remains unchanged, indicating a potential stale endpoint.
 	StaleBlockNumberCheckInterval = 15
 )
+
+//EndpointsContextTimeout defines the maximum duration in seconds to wait for establishing a connection for an endpoint
+const EndpointsContextTimeout = 5
 
 //APIKeyRegex will be used as a regular expression to be matched in job Urls
 const APIKeyRegex = `\$\{(.+?)\}`
@@ -83,9 +89,6 @@ const (
 	ProcessRequestRetryAttempts uint  = 2
 	ProcessRequestRetryDelay    int64 = 2
 )
-
-//SwitchClientDuration is the time after which alternate client from secondary RPC will be switched back to client from primary RPC
-const SwitchClientDuration = 5 * EpochLength
 
 const (
 	// HexReturnType is the ReturnType for a job if that job returns a hex value

--- a/core/constants.go
+++ b/core/constants.go
@@ -70,7 +70,10 @@ const (
 )
 
 //BlockNumberInterval is the interval in seconds after which blockNumber needs to be calculated again
-const BlockNumberInterval = 5
+const (
+	BlockNumberInterval           = 5
+	StaleBlockNumberCheckInterval = 15
+)
 
 //APIKeyRegex will be used as a regular expression to be matched in job Urls
 const APIKeyRegex = `\$\{(.+?)\}`

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -25,8 +26,38 @@ type Logger struct {
 	blockMonitor   *block.BlockMonitor
 }
 
-// NewLogger initializes a Logger instance with given parameters.
-func NewLogger(address string, client *ethclient.Client, fileName string, config types.Configurations, blockMonitor *block.BlockMonitor) *Logger {
+// Global logger instance
+var globalLogger = NewLogger("", nil, nil)
+
+// GetLogger returns the global logger instance.
+func GetLogger() *Logger {
+	return globalLogger
+}
+
+// UpdateLogger updates the global logger instance with new parameters.
+func UpdateLogger(address string, client *ethclient.Client, blockMonitor *block.BlockMonitor) {
+	globalLogger.address = address
+	globalLogger.client = client
+	globalLogger.blockMonitor = blockMonitor
+}
+
+func init() {
+	InitializeLogger("", types.Configurations{})
+
+	osInfo := goInfo.GetInfo()
+	globalLogger.logrusInstance.WithFields(logrus.Fields{
+		"Operating System": osInfo.OS,
+		"Core":             osInfo.Core,
+		"Platform":         osInfo.Platform,
+		"CPUs":             osInfo.CPUs,
+		"razor-go version": core.VersionWithMeta,
+		"go version":       runtime.Version(),
+	}).Info()
+
+}
+
+//NewLogger initializes a Logger instance with given parameters.
+func NewLogger(address string, client *ethclient.Client, blockMonitor *block.BlockMonitor) *Logger {
 	logger := &Logger{
 		logrusInstance: logrus.New(),
 		address:        address,
@@ -34,20 +65,18 @@ func NewLogger(address string, client *ethclient.Client, fileName string, config
 		blockMonitor:   blockMonitor,
 	}
 
-	logger.setupLogger(fileName, config)
 	logger.logSystemInfo()
 
 	return logger
 }
 
-// setupLogger configures the logger's output and formatting.
-func (l *Logger) setupLogger(fileName string, config types.Configurations) {
+func InitializeLogger(fileName string, config types.Configurations) {
 	path.PathUtilsInterface = &path.PathUtils{}
 	path.OSUtilsInterface = &path.OSUtils{}
 	if fileName != "" {
 		logFilePath, err := path.PathUtilsInterface.GetLogFilePath(fileName)
 		if err != nil {
-			l.logrusInstance.Fatal("Error in fetching log file path: ", err)
+			globalLogger.Fatal("Error in fetching log file path: ", err)
 		}
 
 		lumberJackLogger := &lumberjack.Logger{
@@ -58,9 +87,9 @@ func (l *Logger) setupLogger(fileName string, config types.Configurations) {
 		}
 
 		mw := io.MultiWriter(os.Stderr, lumberJackLogger)
-		l.logrusInstance.SetOutput(mw)
+		globalLogger.logrusInstance.SetOutput(mw)
 	}
-	l.logrusInstance.Formatter = &logrus.JSONFormatter{}
+	globalLogger.logrusInstance.Formatter = &logrus.JSONFormatter{}
 }
 
 // logSystemInfo logs system-related details at initialization.
@@ -76,83 +105,128 @@ func (l *Logger) logSystemInfo() {
 	}).Info("Logger initialized")
 }
 
-// logWithFields adds context and logs a message with the specified level and format.
-func (l *Logger) logWithFields(level logrus.Level, format string, args ...interface{}) {
+// Error logs a simple error message.
+func (l *Logger) Error(args ...interface{}) {
 	epoch, blockNumber := l.updateBlockInfo()
-	fields := logrus.Fields{
+	logFields := logrus.Fields{
 		"address":     l.address,
 		"epoch":       epoch,
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	entry := l.logrusInstance.WithFields(fields)
-
-	message := fmt.Sprintf(format, args...)
-	switch level {
-	case logrus.InfoLevel:
-		entry.Info(message)
-	case logrus.DebugLevel:
-		entry.Debug(message)
-	case logrus.WarnLevel:
-		entry.Warn(message)
-	case logrus.ErrorLevel:
-		entry.Error(message)
-	case logrus.FatalLevel:
-		entry.Fatal(message)
-		os.Exit(1)
-	default:
-		entry.Print(message)
-	}
+	l.logrusInstance.WithFields(logFields).Errorln(args...)
 }
 
 // Info logs a simple informational message.
 func (l *Logger) Info(args ...interface{}) {
-	l.logWithFields(logrus.InfoLevel, joinString(args...), args...)
-}
-
-// Infof logs a formatted informational message.
-func (l *Logger) Infof(format string, args ...interface{}) {
-	l.logWithFields(logrus.InfoLevel, format, args...)
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	l.logrusInstance.WithFields(logFields).Infoln(args...)
 }
 
 // Debug logs a simple debug message.
 func (l *Logger) Debug(args ...interface{}) {
-	l.logWithFields(logrus.DebugLevel, joinString(args...), args...)
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	l.logrusInstance.WithFields(logFields).Debugln(args...)
 }
 
-// Debugf logs a formatted debug message.
-func (l *Logger) Debugf(format string, args ...interface{}) {
-	l.logWithFields(logrus.DebugLevel, format, args...)
+// Fatal logs a fatal error message and exits the application.
+func (l *Logger) Fatal(args ...interface{}) {
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	errMsg := joinString(args)
+	err := errors.New(errMsg)
+	l.logrusInstance.WithFields(logFields).Fatalln(err)
 }
 
 // Warn logs a simple warning message.
 func (l *Logger) Warn(args ...interface{}) {
-	l.logWithFields(logrus.WarnLevel, joinString(args...), args...)
-}
-
-// Warnf logs a formatted warning message.
-func (l *Logger) Warnf(format string, args ...interface{}) {
-	l.logWithFields(logrus.WarnLevel, format, args...)
-}
-
-// Error logs a simple error message.
-func (l *Logger) Error(args ...interface{}) {
-	l.logWithFields(logrus.ErrorLevel, joinString(args...), args...)
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	l.logrusInstance.WithFields(logFields).Warnln(args...)
 }
 
 // Errorf logs a formatted error message.
 func (l *Logger) Errorf(format string, args ...interface{}) {
-	l.logWithFields(logrus.ErrorLevel, format, args...)
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	l.logrusInstance.WithFields(logFields).Errorf(format, args...)
 }
 
-// Fatal logs a simple fatal error message and exits the application.
-func (l *Logger) Fatal(args ...interface{}) {
-	l.logWithFields(logrus.FatalLevel, joinString(args...), args...)
+// Infof logs a formatted informational message.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	l.logrusInstance.WithFields(logFields).Infof(format, args...)
+}
+
+// Debugf logs a formatted debug message.
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	l.logrusInstance.WithFields(logFields).Debugf(format, args...)
 }
 
 // Fatalf logs a formatted fatal error message and exits the application.
 func (l *Logger) Fatalf(format string, args ...interface{}) {
-	l.logWithFields(logrus.FatalLevel, format, args...)
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	errMsg := joinString(args...)
+	err := errors.New(errMsg)
+	l.logrusInstance.WithFields(logFields).Fatalf(format, err)
+}
+
+// Warnf logs a formatted warning message.
+func (l *Logger) Warnf(format string, args ...interface{}) {
+	epoch, blockNumber := l.updateBlockInfo()
+	logFields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	l.logrusInstance.WithFields(logFields).Warnf(format, args...)
 }
 
 // joinString concatenates multiple arguments into a single string.
@@ -163,16 +237,6 @@ func joinString(args ...interface{}) string {
 		str += " " + msg
 	}
 	return str
-}
-
-// SetAddress updates the logger's address field.
-func (l *Logger) SetAddress(address string) {
-	l.address = address
-}
-
-// SetClient updates the logger's Ethereum client.
-func (l *Logger) SetClient(client *ethclient.Client) {
-	l.client = client
 }
 
 // SetLogLevel sets the log level for the logger instance.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -18,40 +17,37 @@ import (
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
-type StandardLogger struct {
-	*logrus.Logger
+// Logger encapsulates logrus and its dependencies for contextual logging.
+type Logger struct {
+	logrusInstance *logrus.Logger
+	address        string
+	client         *ethclient.Client
+	blockMonitor   *block.BlockMonitor
 }
 
-var standardLogger = &StandardLogger{logrus.New()}
+// NewLogger initializes a Logger instance with given parameters.
+func NewLogger(address string, client *ethclient.Client, fileName string, config types.Configurations, blockMonitor *block.BlockMonitor) *Logger {
+	logger := &Logger{
+		logrusInstance: logrus.New(),
+		address:        address,
+		client:         client,
+		blockMonitor:   blockMonitor,
+	}
 
-var Address string
-var Epoch uint32
-var BlockNumber *big.Int
-var FileName string
-var Client *ethclient.Client
+	logger.setupLogger(fileName, config)
+	logger.logSystemInfo()
 
-func init() {
+	return logger
+}
+
+// setupLogger configures the logger's output and formatting.
+func (l *Logger) setupLogger(fileName string, config types.Configurations) {
 	path.PathUtilsInterface = &path.PathUtils{}
 	path.OSUtilsInterface = &path.OSUtils{}
-	InitializeLogger(FileName, types.Configurations{})
-
-	osInfo := goInfo.GetInfo()
-	standardLogger.WithFields(logrus.Fields{
-		"Operating System": osInfo.OS,
-		"Core":             osInfo.Core,
-		"Platform":         osInfo.Platform,
-		"CPUs":             osInfo.CPUs,
-		"razor-go version": core.VersionWithMeta,
-		"go version":       runtime.Version(),
-	}).Info()
-
-}
-
-func InitializeLogger(fileName string, config types.Configurations) {
 	if fileName != "" {
 		logFilePath, err := path.PathUtilsInterface.GetLogFilePath(fileName)
 		if err != nil {
-			standardLogger.Fatal("Error in fetching log file path: ", err)
+			l.logrusInstance.Fatal("Error in fetching log file path: ", err)
 		}
 
 		lumberJackLogger := &lumberjack.Logger{
@@ -61,17 +57,105 @@ func InitializeLogger(fileName string, config types.Configurations) {
 			MaxAge:     config.LogFileMaxAge,
 		}
 
-		out := os.Stderr
-		mw := io.MultiWriter(out, lumberJackLogger)
-		standardLogger.SetOutput(mw)
+		mw := io.MultiWriter(os.Stderr, lumberJackLogger)
+		l.logrusInstance.SetOutput(mw)
 	}
-	standardLogger.Formatter = &logrus.JSONFormatter{}
+	l.logrusInstance.Formatter = &logrus.JSONFormatter{}
 }
 
-func NewLogger() *StandardLogger {
-	return standardLogger
+// logSystemInfo logs system-related details at initialization.
+func (l *Logger) logSystemInfo() {
+	osInfo := goInfo.GetInfo()
+	l.logrusInstance.WithFields(logrus.Fields{
+		"Operating System": osInfo.OS,
+		"Core":             osInfo.Core,
+		"Platform":         osInfo.Platform,
+		"CPUs":             osInfo.CPUs,
+		"razor-go version": core.VersionWithMeta,
+		"go version":       runtime.Version(),
+	}).Info("Logger initialized")
 }
 
+// logWithFields adds context and logs a message with the specified level and format.
+func (l *Logger) logWithFields(level logrus.Level, format string, args ...interface{}) {
+	epoch, blockNumber := l.updateBlockInfo()
+	fields := logrus.Fields{
+		"address":     l.address,
+		"epoch":       epoch,
+		"blockNumber": blockNumber,
+		"version":     core.VersionWithMeta,
+	}
+	entry := l.logrusInstance.WithFields(fields)
+
+	message := fmt.Sprintf(format, args...)
+	switch level {
+	case logrus.InfoLevel:
+		entry.Info(message)
+	case logrus.DebugLevel:
+		entry.Debug(message)
+	case logrus.WarnLevel:
+		entry.Warn(message)
+	case logrus.ErrorLevel:
+		entry.Error(message)
+	case logrus.FatalLevel:
+		entry.Fatal(message)
+		os.Exit(1)
+	default:
+		entry.Print(message)
+	}
+}
+
+// Info logs a simple informational message.
+func (l *Logger) Info(args ...interface{}) {
+	l.logWithFields(logrus.InfoLevel, joinString(args...), args...)
+}
+
+// Infof logs a formatted informational message.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	l.logWithFields(logrus.InfoLevel, format, args...)
+}
+
+// Debug logs a simple debug message.
+func (l *Logger) Debug(args ...interface{}) {
+	l.logWithFields(logrus.DebugLevel, joinString(args...), args...)
+}
+
+// Debugf logs a formatted debug message.
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	l.logWithFields(logrus.DebugLevel, format, args...)
+}
+
+// Warn logs a simple warning message.
+func (l *Logger) Warn(args ...interface{}) {
+	l.logWithFields(logrus.WarnLevel, joinString(args...), args...)
+}
+
+// Warnf logs a formatted warning message.
+func (l *Logger) Warnf(format string, args ...interface{}) {
+	l.logWithFields(logrus.WarnLevel, format, args...)
+}
+
+// Error logs a simple error message.
+func (l *Logger) Error(args ...interface{}) {
+	l.logWithFields(logrus.ErrorLevel, joinString(args...), args...)
+}
+
+// Errorf logs a formatted error message.
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.logWithFields(logrus.ErrorLevel, format, args...)
+}
+
+// Fatal logs a simple fatal error message and exits the application.
+func (l *Logger) Fatal(args ...interface{}) {
+	l.logWithFields(logrus.FatalLevel, joinString(args...), args...)
+}
+
+// Fatalf logs a formatted fatal error message and exits the application.
+func (l *Logger) Fatalf(format string, args ...interface{}) {
+	l.logWithFields(logrus.FatalLevel, format, args...)
+}
+
+// joinString concatenates multiple arguments into a single string.
 func joinString(args ...interface{}) string {
 	str := ""
 	for index := 0; index < len(args); index++ {
@@ -81,111 +165,30 @@ func joinString(args ...interface{}) string {
 	return str
 }
 
-func (logger *StandardLogger) Error(args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
-	}
-	logger.WithFields(logFields).Errorln(args...)
+// SetAddress updates the logger's address field.
+func (l *Logger) SetAddress(address string) {
+	l.address = address
 }
 
-func (logger *StandardLogger) Info(args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
-	}
-	logger.WithFields(logFields).Infoln(args...)
+// SetClient updates the logger's Ethereum client.
+func (l *Logger) SetClient(client *ethclient.Client) {
+	l.client = client
 }
 
-func (logger *StandardLogger) Debug(args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
-	}
-	logger.WithFields(logFields).Debugln(args...)
+// SetLogLevel sets the log level for the logger instance.
+func (l *Logger) SetLogLevel(level logrus.Level) {
+	l.logrusInstance.SetLevel(level)
 }
 
-func (logger *StandardLogger) Fatal(args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
+// updateBlockInfo fetches block info from the BlockMonitor.
+func (l *Logger) updateBlockInfo() (uint32, *big.Int) {
+	if l.blockMonitor == nil {
+		return 0, nil
 	}
-	errMsg := joinString(args)
-	err := errors.New(errMsg)
-	logger.WithFields(logFields).Fatalln(err)
-}
-
-func (logger *StandardLogger) Errorf(format string, args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
+	latestBlock := l.blockMonitor.GetLatestBlock()
+	if latestBlock != nil {
+		epoch := uint32(latestBlock.Time / core.EpochLength)
+		return epoch, latestBlock.Number
 	}
-	logger.WithFields(logFields).Errorf(format, args...)
-}
-
-func (logger *StandardLogger) Infof(format string, args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
-	}
-	logger.WithFields(logFields).Infof(format, args...)
-}
-
-func (logger *StandardLogger) Debugf(format string, args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
-	}
-	logger.WithFields(logFields).Debugf(format, args...)
-}
-
-func (logger *StandardLogger) Fatalf(format string, args ...interface{}) {
-	SetEpochAndBlockNumber(Client)
-	var logFields = logrus.Fields{
-		"address":     Address,
-		"epoch":       Epoch,
-		"blockNumber": BlockNumber,
-		"version":     core.VersionWithMeta,
-	}
-	errMsg := joinString(args)
-	err := errors.New(errMsg)
-	logger.WithFields(logFields).Fatalf(format, err)
-}
-
-func SetEpochAndBlockNumber(client *ethclient.Client) {
-	if client != nil {
-		latestBlock := block.GetLatestBlock()
-		if latestBlock != nil {
-			BlockNumber = latestBlock.Number
-			epoch := latestBlock.Time / core.EpochLength
-			Epoch = uint32(epoch)
-		}
-	}
-}
-
-func SetLoggerParameters(client *ethclient.Client, address string) {
-	Address = address
-	Client = client
-	go block.CalculateLatestBlock(client)
+	return 0, nil
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,7 +20,7 @@ import (
 
 // Logger encapsulates logrus and its dependencies for contextual logging.
 type Logger struct {
-	logrusInstance *logrus.Logger
+	LogrusInstance *logrus.Logger
 	address        string
 	client         *ethclient.Client
 	blockMonitor   *block.BlockMonitor
@@ -45,7 +45,7 @@ func init() {
 	InitializeLogger("", types.Configurations{})
 
 	osInfo := goInfo.GetInfo()
-	globalLogger.logrusInstance.WithFields(logrus.Fields{
+	globalLogger.LogrusInstance.WithFields(logrus.Fields{
 		"Operating System": osInfo.OS,
 		"Core":             osInfo.Core,
 		"Platform":         osInfo.Platform,
@@ -59,7 +59,7 @@ func init() {
 //NewLogger initializes a Logger instance with given parameters.
 func NewLogger(address string, client *ethclient.Client, blockMonitor *block.BlockMonitor) *Logger {
 	logger := &Logger{
-		logrusInstance: logrus.New(),
+		LogrusInstance: logrus.New(),
 		address:        address,
 		client:         client,
 		blockMonitor:   blockMonitor,
@@ -87,15 +87,15 @@ func InitializeLogger(fileName string, config types.Configurations) {
 		}
 
 		mw := io.MultiWriter(os.Stderr, lumberJackLogger)
-		globalLogger.logrusInstance.SetOutput(mw)
+		globalLogger.LogrusInstance.SetOutput(mw)
 	}
-	globalLogger.logrusInstance.Formatter = &logrus.JSONFormatter{}
+	globalLogger.LogrusInstance.Formatter = &logrus.JSONFormatter{}
 }
 
 // logSystemInfo logs system-related details at initialization.
 func (l *Logger) logSystemInfo() {
 	osInfo := goInfo.GetInfo()
-	l.logrusInstance.WithFields(logrus.Fields{
+	l.LogrusInstance.WithFields(logrus.Fields{
 		"Operating System": osInfo.OS,
 		"Core":             osInfo.Core,
 		"Platform":         osInfo.Platform,
@@ -114,7 +114,7 @@ func (l *Logger) Error(args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Errorln(args...)
+	l.LogrusInstance.WithFields(logFields).Errorln(args...)
 }
 
 // Info logs a simple informational message.
@@ -126,7 +126,7 @@ func (l *Logger) Info(args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Infoln(args...)
+	l.LogrusInstance.WithFields(logFields).Infoln(args...)
 }
 
 // Debug logs a simple debug message.
@@ -138,7 +138,7 @@ func (l *Logger) Debug(args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Debugln(args...)
+	l.LogrusInstance.WithFields(logFields).Debugln(args...)
 }
 
 // Fatal logs a fatal error message and exits the application.
@@ -152,7 +152,7 @@ func (l *Logger) Fatal(args ...interface{}) {
 	}
 	errMsg := joinString(args)
 	err := errors.New(errMsg)
-	l.logrusInstance.WithFields(logFields).Fatalln(err)
+	l.LogrusInstance.WithFields(logFields).Fatalln(err)
 }
 
 // Warn logs a simple warning message.
@@ -164,7 +164,7 @@ func (l *Logger) Warn(args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Warnln(args...)
+	l.LogrusInstance.WithFields(logFields).Warnln(args...)
 }
 
 // Errorf logs a formatted error message.
@@ -176,7 +176,7 @@ func (l *Logger) Errorf(format string, args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Errorf(format, args...)
+	l.LogrusInstance.WithFields(logFields).Errorf(format, args...)
 }
 
 // Infof logs a formatted informational message.
@@ -188,7 +188,7 @@ func (l *Logger) Infof(format string, args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Infof(format, args...)
+	l.LogrusInstance.WithFields(logFields).Infof(format, args...)
 }
 
 // Debugf logs a formatted debug message.
@@ -200,7 +200,7 @@ func (l *Logger) Debugf(format string, args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Debugf(format, args...)
+	l.LogrusInstance.WithFields(logFields).Debugf(format, args...)
 }
 
 // Fatalf logs a formatted fatal error message and exits the application.
@@ -214,7 +214,7 @@ func (l *Logger) Fatalf(format string, args ...interface{}) {
 	}
 	errMsg := joinString(args...)
 	err := errors.New(errMsg)
-	l.logrusInstance.WithFields(logFields).Fatalf(format, err)
+	l.LogrusInstance.WithFields(logFields).Fatalf(format, err)
 }
 
 // Warnf logs a formatted warning message.
@@ -226,7 +226,7 @@ func (l *Logger) Warnf(format string, args ...interface{}) {
 		"blockNumber": blockNumber,
 		"version":     core.VersionWithMeta,
 	}
-	l.logrusInstance.WithFields(logFields).Warnf(format, args...)
+	l.LogrusInstance.WithFields(logFields).Warnf(format, args...)
 }
 
 // joinString concatenates multiple arguments into a single string.
@@ -241,7 +241,7 @@ func joinString(args ...interface{}) string {
 
 // SetLogLevel sets the log level for the logger instance.
 func (l *Logger) SetLogLevel(level logrus.Level) {
-	l.logrusInstance.SetLevel(level)
+	l.LogrusInstance.SetLevel(level)
 }
 
 // updateBlockInfo fetches block info from the BlockMonitor.

--- a/utils/common.go
+++ b/utils/common.go
@@ -10,6 +10,7 @@ import (
 	"razor/accounts"
 	"razor/core"
 	"razor/core/types"
+	"razor/logger"
 	"time"
 
 	Types "github.com/ethereum/go-ethereum/core/types"
@@ -281,18 +282,17 @@ func (*FileStruct) ReadFromCommitJsonFile(filePath string) (types.CommitFileData
 	return commitedData, nil
 }
 
-func (*FileStruct) AssignLogFile(flagSet *pflag.FlagSet) (string, error) {
+func (*FileStruct) AssignLogFile(flagSet *pflag.FlagSet, configurations types.Configurations) {
 	if UtilsInterface.IsFlagPassed("logFile") {
 		fileName, err := FlagSetInterface.GetLogFileName(flagSet)
 		if err != nil {
-			log.Error("Error in getting file name: ", err)
-			return "", err
+			log.Fatal("Error in getting file name: ", err)
 		}
 		log.Debug("Log file name: ", fileName)
-		return fileName, nil
+		logger.InitializeLogger(fileName, configurations)
+	} else {
+		log.Debug("No `logFile` flag passed, not storing logs in any file")
 	}
-	log.Debug("No `logFile` flag passed, not storing logs in any file")
-	return "", nil
 }
 
 func (*FileStruct) SaveDataToProposeJsonFile(filePath string, proposeData types.ProposeFileData) error {

--- a/utils/common.go
+++ b/utils/common.go
@@ -10,7 +10,6 @@ import (
 	"razor/accounts"
 	"razor/core"
 	"razor/core/types"
-	"razor/logger"
 	"time"
 
 	Types "github.com/ethereum/go-ethereum/core/types"
@@ -282,17 +281,18 @@ func (*FileStruct) ReadFromCommitJsonFile(filePath string) (types.CommitFileData
 	return commitedData, nil
 }
 
-func (*FileStruct) AssignLogFile(flagSet *pflag.FlagSet, configurations types.Configurations) {
+func (*FileStruct) AssignLogFile(flagSet *pflag.FlagSet) (string, error) {
 	if UtilsInterface.IsFlagPassed("logFile") {
 		fileName, err := FlagSetInterface.GetLogFileName(flagSet)
 		if err != nil {
-			log.Fatal("Error in getting file name: ", err)
+			log.Error("Error in getting file name: ", err)
+			return "", err
 		}
 		log.Debug("Log file name: ", fileName)
-		logger.InitializeLogger(fileName, configurations)
-	} else {
-		log.Debug("No `logFile` flag passed, not storing logs in any file")
+		return fileName, nil
 	}
+	log.Debug("No `logFile` flag passed, not storing logs in any file")
+	return "", nil
 }
 
 func (*FileStruct) SaveDataToProposeJsonFile(filePath string, proposeData types.ProposeFileData) error {

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -96,9 +96,9 @@ func TestCalculateBlockTime(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -158,9 +158,9 @@ func TestCheckEthBalanceIsZero(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -214,9 +214,9 @@ func TestCheckTransactionReceipt(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -269,9 +269,9 @@ func TestConnectToClient(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -804,9 +804,9 @@ func TestAssignStakerId(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -871,9 +871,9 @@ func TestAssignLogFile(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/utils/contract-manager_test.go
+++ b/utils/contract-manager_test.go
@@ -38,9 +38,9 @@ func TestGetStakeManager(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -91,9 +91,9 @@ func TestGetStakedToken(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -143,9 +143,9 @@ func TestGetTokenManager(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -195,9 +195,9 @@ func TestGetAssetManager(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -247,9 +247,9 @@ func TestGetBlockManager(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -299,9 +299,9 @@ func TestGetVoteManager(t *testing.T) {
 			expectedFatal: true,
 		},
 	}
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -321,7 +321,7 @@ type FileUtils interface {
 	ReadFromProposeJsonFile(filePath string) (types.ProposeFileData, error)
 	SaveDataToDisputeJsonFile(filePath string, bountyIdQueue []uint32) error
 	ReadFromDisputeJsonFile(filePath string) (types.DisputeFileData, error)
-	AssignLogFile(flagSet *pflag.FlagSet, configurations types.Configurations)
+	AssignLogFile(flagSet *pflag.FlagSet) (string, error)
 }
 
 type GasUtils interface {

--- a/utils/interface.go
+++ b/utils/interface.go
@@ -321,7 +321,7 @@ type FileUtils interface {
 	ReadFromProposeJsonFile(filePath string) (types.ProposeFileData, error)
 	SaveDataToDisputeJsonFile(filePath string, bountyIdQueue []uint32) error
 	ReadFromDisputeJsonFile(filePath string) (types.DisputeFileData, error)
-	AssignLogFile(flagSet *pflag.FlagSet) (string, error)
+	AssignLogFile(flagSet *pflag.FlagSet, configurations types.Configurations)
 }
 
 type GasUtils interface {

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,5 +1,14 @@
 package utils
 
-import "razor/logger"
+import (
+	"github.com/ethereum/go-ethereum/ethclient"
+	"razor/block"
+	"razor/core/types"
+	"razor/logger"
+)
 
-var log = logger.NewLogger()
+var log = logger.NewLogger("", &ethclient.Client{}, "", types.Configurations{}, &block.BlockMonitor{})
+
+func UpdateUtilsLogger(updatedLogger *logger.Logger) {
+	log = updatedLogger
+}

--- a/utils/log.go
+++ b/utils/log.go
@@ -1,14 +1,7 @@
 package utils
 
 import (
-	"github.com/ethereum/go-ethereum/ethclient"
-	"razor/block"
-	"razor/core/types"
 	"razor/logger"
 )
 
-var log = logger.NewLogger("", &ethclient.Client{}, "", types.Configurations{}, &block.BlockMonitor{})
-
-func UpdateUtilsLogger(updatedLogger *logger.Logger) {
-	log = updatedLogger
-}
+var log = logger.GetLogger()

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -258,9 +258,9 @@ func TestCheckAmountAndBalance(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/utils/options_test.go
+++ b/utils/options_test.go
@@ -100,9 +100,9 @@ func Test_getGasPrice(t *testing.T) {
 		},
 	}
 
-	defer func() { log.ExitFunc = nil }()
+	defer func() { log.LogrusInstance.ExitFunc = nil }()
 	var fatal bool
-	log.ExitFunc = func(int) { fatal = true }
+	log.LogrusInstance.ExitFunc = func(int) { fatal = true }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -252,15 +252,15 @@ func Test_utils_GetTxnOpts(t *testing.T) {
 		},
 	}
 
-	originalExitFunc := log.ExitFunc                   // Preserve the original ExitFunc
-	defer func() { log.ExitFunc = originalExitFunc }() // Ensure it's reset after tests
+	originalExitFunc := log.LogrusInstance.ExitFunc                   // Preserve the original ExitFunc
+	defer func() { log.LogrusInstance.ExitFunc = originalExitFunc }() // Ensure it's reset after tests
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fatalOccurred := false
 
 			// Override log.ExitFunc to induce a panic for testing the fatal scenario
-			log.ExitFunc = func(int) { panic("log.Fatal called") }
+			log.LogrusInstance.ExitFunc = func(int) { panic("log.Fatal called") }
 
 			var account types.Account
 			accountManager := accounts.NewAccountManager("test_accounts")

--- a/utils/struct-utils.go
+++ b/utils/struct-utils.go
@@ -166,14 +166,20 @@ func InvokeFunctionWithRetryAttempts(rpcParameters RPC.RPCParameters, interfaceN
 			log.Errorf("%v error after retries: %v", methodName, err)
 			log.Info("Attempting to switch to a new best RPC endpoint...")
 
-			// Attempt to switch to the next best client
-			switchErr := rpcParameters.RPCManager.SwitchToNextBestRPCClient()
+			switched, switchErr := rpcParameters.RPCManager.SwitchToNextBestRPCClient()
 			if switchErr != nil {
 				log.Errorf("Failed to switch to the next best client: %v", switchErr)
 				return returnedValues, switchErr
 			}
+
+			if switched {
+				log.Infof("Successfully switched to a new RPC endpoint after RPC error.")
+			} else {
+				log.Warnf("No switch occurred. Retaining the current RPC client.")
+			}
 		}
 	}
+
 	return returnedValues, err
 }
 


### PR DESCRIPTION
# Description

- This PR refactors the logger and block module.
- In logger module , all the global variables for logger fields are removed.
- In block module , a new blockMonitor struct is introduced which will will monitor and return the blocks whenever needed. 

Fixes # Part of https://linear.app/interstellar-research/issue/RAZ-1026

# How Has This Been Tested?

Ran a staker vote command with multiple RPC's (1 active and 1 inactive RPC). 
Made an attempt to make switch to the next RPC (by disconnecting from internet) which worked as expected maing the current best RPC to move to switch to the next one.