### PR TITLE
fix: switch RPC if block number is less than last recorded block number

### DIFF
--- a/block/block_test.go
+++ b/block/block_test.go
@@ -1,0 +1,240 @@
+package block
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"razor/rpc"
+)
+
+func makeBlockHandler(blockNumber uint64, blockTime uint64) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		method, ok := req["method"].(string)
+		if !ok {
+			http.Error(w, "missing method", http.StatusBadRequest)
+			return
+		}
+
+		var result interface{}
+
+		switch method {
+		case "eth_blockNumber":
+			result = fmt.Sprintf("0x%x", blockNumber)
+
+		case "eth_getBlockByNumber":
+			// Use go-ethereum's types.Header struct to ensure all required fields are included
+			header := &types.Header{
+				Number:      big.NewInt(int64(blockNumber)),
+				Time:        blockTime,
+				ParentHash:  common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+				UncleHash:   types.EmptyUncleHash,
+				Coinbase:    common.HexToAddress("0x0000000000000000000000000000000000000000"),
+				Root:        common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+				TxHash:      common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333"),
+				ReceiptHash: common.HexToHash("0x4444444444444444444444444444444444444444444444444444444444444444"),
+				Bloom:       types.Bloom{},
+				Difficulty:  big.NewInt(2),
+				GasLimit:    30000000,
+				GasUsed:     0,
+				Extra:       []byte{},
+			}
+
+			// Serialize the header to JSON format
+			result = header
+		default:
+			http.Error(w, "unsupported method", http.StatusBadRequest)
+			return
+		}
+
+		resp := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      req["id"],
+			"result":  result,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// createManagerFromServers creates an RPCManager from a list of test servers.
+func createManagerFromServers(servers ...*httptest.Server) *rpc.RPCManager {
+	endpoints := make([]*rpc.RPCEndpoint, len(servers))
+	for i, s := range servers {
+		endpoints[i] = &rpc.RPCEndpoint{URL: s.URL}
+	}
+	return &rpc.RPCManager{Endpoints: endpoints}
+}
+
+// TestBlockMonitorUpdateBlock tests `updateLatestBlock` behavior with different block numbers.
+func TestBlockMonitorUpdateBlock(t *testing.T) {
+	// Simulate two endpoints: one returning an outdated block, another returning an up-to-date block.
+	blockNumber := uint64(100)
+	outdatedBlockNumber := uint64(90)
+
+	ts1 := httptest.NewServer(makeBlockHandler(blockNumber, uint64(time.Now().Unix())))
+	t.Cleanup(func() { ts1.Close() })
+
+	ts2 := httptest.NewServer(makeBlockHandler(outdatedBlockNumber, uint64(time.Now().Unix())))
+	t.Cleanup(func() { ts2.Close() })
+
+	// Create an RPC manager with both endpoints.
+	manager := createManagerFromServers(ts1, ts2)
+
+	// Refresh endpoints so that the manager pings each endpoint.
+	if err := manager.RefreshEndpoints(); err != nil {
+		t.Fatalf("RefreshEndpoints failed: %v", err)
+	}
+
+	// Initialize BlockMonitor.
+	client, _ := manager.GetBestRPCClient()
+	bm := NewBlockMonitor(client, manager, 1, 10)
+
+	// Simulate fetching the latest block.
+	bm.updateLatestBlock()
+
+	if bm.latestBlock == nil {
+		t.Fatal("Expected latest block to be set, but got nil")
+	}
+
+	// Ensure that the latest block number is from the correct, up-to-date endpoint.
+	if bm.latestBlock.Number.Uint64() != blockNumber {
+		t.Errorf("Expected block number %d, got %d", blockNumber, bm.latestBlock.Number.Uint64())
+	}
+
+	// Simulate outdated block number being reported.
+	bm.latestBlock.Number = big.NewInt(int64(outdatedBlockNumber))
+	bm.updateLatestBlock()
+
+	// The block number should remain at the latest, and an RPC switch should have occurred.
+	newBestURL, _ := manager.GetBestEndpointURL()
+	if newBestURL != ts1.URL {
+		t.Errorf("Expected best endpoint to be %s after outdated block, got %s", ts1.URL, newBestURL)
+	}
+}
+
+// TestBlockMonitorStaleBlock checks if the stale block detection works correctly.
+func TestBlockMonitorStaleBlock(t *testing.T) {
+	currentTime := uint64(time.Now().Unix())
+	staleTime := uint64(time.Now().Add(-15 * time.Second).Unix())
+
+	ts1 := httptest.NewServer(makeBlockHandler(120, currentTime))
+	t.Cleanup(func() { ts1.Close() })
+
+	ts2 := httptest.NewServer(makeBlockHandler(110, staleTime))
+	t.Cleanup(func() { ts2.Close() })
+
+	// Create an RPC manager with both endpoints.
+	manager := createManagerFromServers(ts1, ts2)
+
+	// Refresh endpoints so that the manager pings each endpoint.
+	if err := manager.RefreshEndpoints(); err != nil {
+		t.Fatalf("RefreshEndpoints failed: %v", err)
+	}
+
+	// Initialize BlockMonitor.
+	client, _ := manager.GetBestRPCClient()
+	bm := NewBlockMonitor(client, manager, 1, 10)
+
+	// Fetch the latest block (stale one)
+	bm.updateLatestBlock()
+	bm.checkForStaleBlock()
+
+	if bm.latestBlock.Number.Uint64() != 120 {
+		t.Errorf("Expected block number 120 after detecting stale block, got %d", bm.latestBlock.Number.Uint64())
+	}
+}
+
+// TestBlockMonitorSwitchOnStale tests switching to a better endpoint when a stale block is detected.
+func TestBlockMonitorSwitchOnStale(t *testing.T) {
+	latestBlock := uint64(150)
+	staleBlock := uint64(140)
+
+	var blockNumber atomic.Uint64
+	blockNumber.Store(staleBlock)
+
+	// Simulate a server that starts with a stale block but updates to a fresh block.
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		makeBlockHandler(blockNumber.Load(), uint64(time.Now().Unix()))(w, r)
+	}))
+	t.Cleanup(func() { ts1.Close() })
+
+	ts2 := httptest.NewServer(makeBlockHandler(latestBlock, uint64(time.Now().Unix())))
+	t.Cleanup(func() { ts2.Close() })
+
+	// Create an RPC manager.
+	manager := createManagerFromServers(ts1, ts2)
+
+	// Refresh endpoints so that the manager pings each endpoint.
+	if err := manager.RefreshEndpoints(); err != nil {
+		t.Fatalf("RefreshEndpoints failed: %v", err)
+	}
+
+	// Initialize BlockMonitor.
+	client, _ := manager.GetBestRPCClient()
+	bm := NewBlockMonitor(client, manager, 1, 10)
+
+	// Start with a stale block.
+	blockNumber.Store(staleBlock)
+	bm.updateLatestBlock()
+	bm.checkForStaleBlock()
+
+	// Ensure the switch occurred to the better endpoint.
+	bestURL, _ := manager.GetBestEndpointURL()
+	if bestURL != ts2.URL {
+		t.Errorf("Expected best endpoint to switch to %s, got %s", ts2.URL, bestURL)
+	}
+
+	// Now update the first endpoint to a fresh block.
+	blockNumber.Store(latestBlock)
+	bm.updateLatestBlock()
+	bm.checkForStaleBlock()
+
+	// The monitor should detect the updated block.
+	if bm.latestBlock.Number.Uint64() != latestBlock {
+		t.Errorf("Expected latest block number %d, got %d", latestBlock, bm.latestBlock.Number.Uint64())
+	}
+}
+
+// TestBlockMonitorSwitchFailure tests when no alternate endpoints are available.
+func TestBlockMonitorSwitchFailure(t *testing.T) {
+	staleBlock := uint64(80)
+
+	ts1 := httptest.NewServer(makeBlockHandler(staleBlock, uint64(time.Now().Add(-20*time.Second).Unix())))
+	t.Cleanup(func() { ts1.Close() })
+
+	// Create an RPC manager with a single stale endpoint.
+	manager := createManagerFromServers(ts1)
+
+	// Refresh endpoints so that the manager pings each endpoint.
+	if err := manager.RefreshEndpoints(); err != nil {
+		t.Fatalf("RefreshEndpoints failed: %v", err)
+	}
+
+	// Initialize BlockMonitor.
+	client, _ := manager.GetBestRPCClient()
+	bm := NewBlockMonitor(client, manager, 1, 10)
+
+	// Start with a stale block.
+	bm.updateLatestBlock()
+	bm.checkForStaleBlock()
+
+	// Since no alternate endpoints are available, the best endpoint should remain unchanged.
+	bestURL, _ := manager.GetBestEndpointURL()
+	if bestURL != ts1.URL {
+		t.Errorf("Expected best endpoint to remain %s, got %s", ts1.URL, bestURL)
+	}
+}


### PR DESCRIPTION
### **User description**
# Description

There was an instance when an RPC reported an outdated block number and current block monitor doesn't handle the scenario.
So there is a need for Block Monitor module to detect scenarios where the newly fetched block number is less than the last recorded block number.

Fixes https://linear.app/interstellar-research/issue/RAZ-1178

# Solution

Compared the newly fetched block number with the last recorded block number in `updateLatestBlock()` in block monitor module and triggered an RPC switch if the new block number is lower than the recorded block number.

# How Has This Been Tested?

Created scenarios to return an older block number from `HeaderByNumber` call by modifying the function and tested whether RPC was switched correctly or not.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added logic to detect outdated block numbers and switch RPC endpoints.

- Implemented tests to validate block monitor behavior under various scenarios.

- Enhanced error handling for RPC endpoint switching failures.

- Introduced mock servers for simulating RPC responses in tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>block.go</strong><dd><code>Add outdated block detection and RPC switching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

block/block.go

<li>Added logic to detect outdated block numbers.<br> <li> Implemented RPC endpoint switching when outdated blocks are detected.<br> <li> Enhanced logging for block monitoring and RPC switching.


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1264/files#diff-9a93a4d3f3ae40bcc564c225e9122a3d92f49c2a187b5da9f52715348766f788">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>block_test.go</strong><dd><code>Add tests for block monitor and RPC switching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

block/block_test.go

<li>Added tests for detecting outdated blocks and switching RPC endpoints.<br> <li> Simulated various scenarios using mock servers.<br> <li> Validated stale block detection and endpoint switching logic.


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1264/files#diff-3507cd06e4a30b1f9b285faf8c287e29b553ab04ee6b3c3613fa8543263050f4">+240/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>