### PR TITLE
hotfix: added validation to check if index to fetch element is within limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           mv razor_go.linux-amd64.tar.gz ../../
 
       - name: Upload AMD Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: razor_go.linux-amd64.tar.gz
           path: razor_go.linux-amd64.tar.gz
@@ -173,7 +173,7 @@ jobs:
           mv razor_go.linux-arm64.tar.gz ../../
 
       - name: Upload ARM Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: razor_go.linux-arm64.tar.gz
           path: razor_go.linux-arm64.tar.gz
@@ -197,12 +197,12 @@ jobs:
           node-version: "20"
 
       - name: Download Artifacts AMD
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: razor_go.linux-amd64.tar.gz
 
       - name: Download Artifacts ARM
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: razor_go.linux-arm64.tar.gz
 

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -113,6 +113,12 @@ func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configuration
 			return err
 		}
 		log.Debug("Propose: Sorted proposed blocks: ", sortedProposedBlocks)
+
+		if len(sortedProposedBlocks) < int(numOfProposedBlocks) {
+			log.Errorf("Mismatch: numOfProposedBlocks (%d) is greater than sortedProposedBlocks length (%d)", numOfProposedBlocks, len(sortedProposedBlocks))
+			return errors.New("proposed blocks count mismatch")
+		}
+
 		lastBlockIndex := sortedProposedBlocks[numOfProposedBlocks-1]
 		log.Debug("Propose: Last block index: ", lastBlockIndex)
 		lastProposedBlockStruct, err := razorUtils.GetProposedBlock(client, epoch, lastBlockIndex)

--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -114,8 +114,8 @@ func (*UtilsStruct) Propose(client *ethclient.Client, config types.Configuration
 		}
 		log.Debug("Propose: Sorted proposed blocks: ", sortedProposedBlocks)
 
-		if len(sortedProposedBlocks) < int(numOfProposedBlocks) {
-			log.Errorf("Mismatch: numOfProposedBlocks (%d) is greater than sortedProposedBlocks length (%d)", numOfProposedBlocks, len(sortedProposedBlocks))
+		if numOfProposedBlocks <= 0 || len(sortedProposedBlocks) < int(numOfProposedBlocks) {
+			log.Errorf("Invalid numOfProposedBlocks (%d) or mismatch with sortedProposedBlocks length (%d)", numOfProposedBlocks, len(sortedProposedBlocks))
 			return errors.New("proposed blocks count mismatch")
 		}
 

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -501,6 +501,21 @@ func TestPropose(t *testing.T) {
 			},
 			wantErr: errors.New("waitForBlockCompletion error"),
 		},
+		{
+			name: "Test 20: When there is a mismatch in number of proposed blocks and length of sorted proposed blocks array",
+			args: args{
+				state:                  2,
+				staker:                 bindings.StructsStaker{},
+				numStakers:             5,
+				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				biggestStakerId:        2,
+				salt:                   saltBytes32,
+				iteration:              1,
+				numOfProposedBlocks:    3,
+				sortedProposedBlockIds: []uint32{2, 1},
+			},
+			wantErr: errors.New("proposed blocks count mismatch"),
+		},
 	}
 	for _, tt := range tests {
 		SetUpMockInterfaces()


### PR DESCRIPTION
### **User description**
# Description

Due to an RPC issue sometimes node was not able to fetch array length correctly from blockchain which was causing a staker to panic.

Fixes https://linear.app/interstellar-research/issue/RAZ-1241

# How Has This Been Tested?

Ran a staker for few epochs.


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Added validation to check if `numOfProposedBlocks` exceeds `sortedProposedBlocks` length.

- Introduced a new test case for the validation logic.

- Updated GitHub Actions workflow to use newer versions of artifact actions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>propose.go</strong><dd><code>Add validation for proposed blocks count mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/propose.go

<li>Added validation to ensure <code>numOfProposedBlocks</code> does not exceed <br><code>sortedProposedBlocks</code> length.<br> <li> Returned an error if the mismatch occurs.


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1267/files#diff-5b85926c2bb6a36cc090f0cef10f19b2649be8e4b2c2de5323c6e1efabe3e66f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>propose_test.go</strong><dd><code>Add test case for proposed blocks count validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/propose_test.go

<li>Added a new test case to validate the mismatch handling logic.<br> <li> Ensured the test case checks for the correct error message.


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1267/files#diff-477c112d01bc7070a8d89f03e2a0228cea459505ac2846bad32b774badb066d3">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Update GitHub Actions artifact actions to v4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<li>Updated <code>actions/upload-artifact</code> to version 4.<br> <li> Updated <code>actions/download-artifact</code> to version 4.


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1267/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>