### PR TITLE
refactor: fetched block number from block monitor module in voting process

### DIFF
--- a/cmd/addStake.go
+++ b/cmd/addStake.go
@@ -32,7 +32,7 @@ func initialiseStake(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the StakeCoins function
 func (*UtilsStruct) ExecuteStake(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	balance, err := razorUtils.FetchBalance(rpcParameters, account.Address)

--- a/cmd/claimBounty.go
+++ b/cmd/claimBounty.go
@@ -34,7 +34,7 @@ func initialiseClaimBounty(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the ClaimBounty function
 func (*UtilsStruct) ExecuteClaimBounty(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	if razorUtils.IsFlagPassed("bountyId") {

--- a/cmd/claimCommission.go
+++ b/cmd/claimCommission.go
@@ -26,7 +26,7 @@ Example:
 
 //This function allows the staker to claim the rewards earned from delegator's pool share as commission
 func (*UtilsStruct) ClaimCommission(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	stakerId, err := razorUtils.GetStakerId(rpcParameters, account.Address)

--- a/cmd/cmd-utils.go
+++ b/cmd/cmd-utils.go
@@ -130,7 +130,7 @@ func GetFormattedStateNames(states []int) string {
 	return statesAllowed
 }
 
-func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations, rpc.RPCParameters, types.Account, error) {
+func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations, rpc.RPCParameters, *block.BlockMonitor, types.Account, error) {
 	var (
 		account       types.Account
 		client        *ethclient.Client
@@ -141,7 +141,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 	config, err := cmdUtils.GetConfigData()
 	if err != nil {
 		log.Error("Error in getting config: ", err)
-		return types.Configurations{}, rpc.RPCParameters{}, types.Account{}, err
+		return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
 	}
 	log.Debugf("Config: %+v", config)
 
@@ -149,7 +149,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 		address, err := flagSetUtils.GetStringAddress(flagSet)
 		if err != nil {
 			log.Error("Error in getting address: ", err)
-			return types.Configurations{}, rpc.RPCParameters{}, types.Account{}, err
+			return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
 		}
 		log.Debugf("Address: %v", address)
 
@@ -159,21 +159,21 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 		accountManager, err := razorUtils.AccountManagerForKeystore()
 		if err != nil {
 			log.Error("Error in getting accounts manager for keystore: ", err)
-			return types.Configurations{}, rpc.RPCParameters{}, types.Account{}, err
+			return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
 		}
 
 		account = accounts.InitAccountStruct(address, password, accountManager)
 		err = razorUtils.CheckPassword(account)
 		if err != nil {
 			log.Error("Error in fetching private key from given password: ", err)
-			return types.Configurations{}, rpc.RPCParameters{}, types.Account{}, err
+			return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
 		}
 	}
 
 	rpcManager, err := rpc.InitializeRPCManager(config.Provider)
 	if err != nil {
 		log.Error("Error in initializing RPC Manager: ", err)
-		return types.Configurations{}, rpc.RPCParameters{}, types.Account{}, err
+		return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
 	}
 
 	rpcParameters = rpc.RPCParameters{
@@ -184,7 +184,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 	client, err = rpcManager.GetBestRPCClient()
 	if err != nil {
 		log.Error("Error in getting best RPC client: ", err)
-		return types.Configurations{}, rpc.RPCParameters{}, types.Account{}, err
+		return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
 	}
 
 	// Initialize BlockMonitor with RPCManager
@@ -196,5 +196,5 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 	// Update Logger Instance
 	logger.UpdateLogger(account.Address, client, blockMonitor)
 
-	return config, rpcParameters, account, nil
+	return config, rpcParameters, blockMonitor, account, nil
 }

--- a/cmd/cmd-utils.go
+++ b/cmd/cmd-utils.go
@@ -141,7 +141,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 	config, err := cmdUtils.GetConfigData()
 	if err != nil {
 		log.Error("Error in getting config: ", err)
-		return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
+		return types.Configurations{}, rpc.RPCParameters{}, nil, types.Account{}, err
 	}
 	log.Debugf("Config: %+v", config)
 
@@ -149,7 +149,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 		address, err := flagSetUtils.GetStringAddress(flagSet)
 		if err != nil {
 			log.Error("Error in getting address: ", err)
-			return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
+			return types.Configurations{}, rpc.RPCParameters{}, nil, types.Account{}, err
 		}
 		log.Debugf("Address: %v", address)
 
@@ -159,21 +159,21 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 		accountManager, err := razorUtils.AccountManagerForKeystore()
 		if err != nil {
 			log.Error("Error in getting accounts manager for keystore: ", err)
-			return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
+			return types.Configurations{}, rpc.RPCParameters{}, nil, types.Account{}, err
 		}
 
 		account = accounts.InitAccountStruct(address, password, accountManager)
 		err = razorUtils.CheckPassword(account)
 		if err != nil {
 			log.Error("Error in fetching private key from given password: ", err)
-			return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
+			return types.Configurations{}, rpc.RPCParameters{}, nil, types.Account{}, err
 		}
 	}
 
 	rpcManager, err := rpc.InitializeRPCManager(config.Provider)
 	if err != nil {
 		log.Error("Error in initializing RPC Manager: ", err)
-		return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
+		return types.Configurations{}, rpc.RPCParameters{}, nil, types.Account{}, err
 	}
 
 	rpcParameters = rpc.RPCParameters{
@@ -184,7 +184,7 @@ func InitializeCommandDependencies(flagSet *pflag.FlagSet) (types.Configurations
 	client, err = rpcManager.GetBestRPCClient()
 	if err != nil {
 		log.Error("Error in getting best RPC client: ", err)
-		return types.Configurations{}, rpc.RPCParameters{}, &block.BlockMonitor{}, types.Account{}, err
+		return types.Configurations{}, rpc.RPCParameters{}, nil, types.Account{}, err
 	}
 
 	// Initialize BlockMonitor with RPCManager

--- a/cmd/collectionList.go
+++ b/cmd/collectionList.go
@@ -31,7 +31,7 @@ func initialiseCollectionList(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and and executes the GetCollectionList function
 func (*UtilsStruct) ExecuteCollectionList(flagSet *pflag.FlagSet) {
-	_, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	_, rpcParameters, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	log.Debug("Calling GetCollectionList()")

--- a/cmd/contractAddresses.go
+++ b/cmd/contractAddresses.go
@@ -25,7 +25,7 @@ func initialiseContractAddresses(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriatley and executes the ContractAddresses function
 func (*UtilsStruct) ExecuteContractAddresses(flagSet *pflag.FlagSet) {
-	_, _, _, err := InitializeCommandDependencies(flagSet)
+	_, _, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	fmt.Println("The contract addresses are: ")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -28,7 +28,7 @@ func initialiseCreate(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the Create function
 func (*UtilsStruct) ExecuteCreate(flagSet *pflag.FlagSet) {
-	_, _, _, err := InitializeCommandDependencies(flagSet)
+	_, _, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 	log.Info("The password should be of minimum 8 characters containing least 1 uppercase, lowercase, digit and special character.")
 	password := razorUtils.AssignPassword(flagSet)

--- a/cmd/createCollection.go
+++ b/cmd/createCollection.go
@@ -34,7 +34,7 @@ func initialiseCreateCollection(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the CreateCollection function
 func (*UtilsStruct) ExecuteCreateCollection(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	name, err := flagSetUtils.GetStringName(flagSet)

--- a/cmd/createJob.go
+++ b/cmd/createJob.go
@@ -35,7 +35,7 @@ func initialiseCreateJob(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the CreateJob function
 func (*UtilsStruct) ExecuteCreateJob(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	name, err := flagSetUtils.GetStringName(flagSet)

--- a/cmd/delegate.go
+++ b/cmd/delegate.go
@@ -32,7 +32,7 @@ func initialiseDelegate(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the Delegate function
 func (*UtilsStruct) ExecuteDelegate(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	stakerId, err := flagSetUtils.GetUint32StakerId(flagSet)

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -29,7 +29,7 @@ func initialiseImport(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the ImportAccount function
 func (*UtilsStruct) ExecuteImport(flagSet *pflag.FlagSet) {
-	_, _, _, err := InitializeCommandDependencies(flagSet)
+	_, _, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 	log.Debug("Calling ImportAccount()...")
 	account, err := cmdUtils.ImportAccount()

--- a/cmd/initiateWithdraw.go
+++ b/cmd/initiateWithdraw.go
@@ -31,7 +31,7 @@ Example:
 
 //This function sets the flags appropriately and executes the InitiateWithdraw function
 func (*UtilsStruct) ExecuteInitiateWithdraw(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	stakerId, err := razorUtils.AssignStakerId(rpcParameters, flagSet, account.Address)

--- a/cmd/interface.go
+++ b/cmd/interface.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"crypto/ecdsa"
 	"math/big"
+	"razor/block"
 	"razor/cache"
 	"razor/core/types"
 	"razor/path"
@@ -225,7 +226,7 @@ type UtilsCmdInterface interface {
 	CalculateSecret(account types.Account, epoch uint32, keystorePath string, chainId *big.Int) ([]byte, []byte, error)
 	HandleBlock(rpcParameters rpc.RPCParameters, account types.Account, stakerId uint32, header *Types.Header, config types.Configurations, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string)
 	ExecuteVote(flagSet *pflag.FlagSet)
-	Vote(rpcParameters rpc.RPCParameters, config types.Configurations, account types.Account, stakerId uint32, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string) error
+	Vote(rpcParameters rpc.RPCParameters, blockMonitor *block.BlockMonitor, config types.Configurations, account types.Account, stakerId uint32, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string) error
 	HandleExit()
 	ExecuteListAccounts(flagSet *pflag.FlagSet)
 	ClaimCommission(flagSet *pflag.FlagSet)

--- a/cmd/jobList.go
+++ b/cmd/jobList.go
@@ -29,7 +29,7 @@ func initialiseJobList(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the GetJobList function
 func (*UtilsStruct) ExecuteJobList(flagSet *pflag.FlagSet) {
-	_, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	_, rpcParameters, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	log.Debug("ExecuteJobList: Calling JobList()...")

--- a/cmd/mocks/utils_cmd_interface.go
+++ b/cmd/mocks/utils_cmd_interface.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	big "math/big"
+	"razor/block"
 	RPC "razor/rpc"
 
 	accounts "github.com/ethereum/go-ethereum/accounts"
@@ -1853,12 +1854,12 @@ func (_m *UtilsCmdInterface) UpdateJob(rpcParameters RPC.RPCParameters, config t
 }
 
 // Vote provides a mock function with given fields: rpcParameters, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore
-func (_m *UtilsCmdInterface) Vote(rpcParameters RPC.RPCParameters, config types.Configurations, account types.Account, stakerId uint32, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string) error {
-	ret := _m.Called(rpcParameters, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore)
+func (_m *UtilsCmdInterface) Vote(rpcParameters RPC.RPCParameters, blockMonitor *block.BlockMonitor, config types.Configurations, account types.Account, stakerId uint32, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string) error {
+	ret := _m.Called(rpcParameters, blockMonitor, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, types.Configurations, types.Account, uint32, *types.CommitParams, types.Rogue, []string) error); ok {
-		r0 = rf(rpcParameters, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore)
+	if rf, ok := ret.Get(0).(func(RPC.RPCParameters, *block.BlockMonitor, types.Configurations, types.Account, uint32, *types.CommitParams, types.Rogue, []string) error); ok {
+		r0 = rf(rpcParameters, blockMonitor, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/cmd/modifyCollectionStatus.go
+++ b/cmd/modifyCollectionStatus.go
@@ -29,7 +29,7 @@ func initialiseModifyCollectionStatus(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the ModifyCollectionStatus function
 func (*UtilsStruct) ExecuteModifyCollectionStatus(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	collectionId, err := flagSetUtils.GetUint16CollectionId(flagSet)

--- a/cmd/resetUnstakeLock.go
+++ b/cmd/resetUnstakeLock.go
@@ -32,7 +32,7 @@ func initialiseExtendLock(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the ResetUnstakeLock function
 func (*UtilsStruct) ExecuteExtendLock(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	stakerId, err := razorUtils.AssignStakerId(rpcParameters, flagSet, account.Address)

--- a/cmd/setConfig.go
+++ b/cmd/setConfig.go
@@ -29,7 +29,7 @@ Example:
 
 // This function returns the error if there is any and sets the config
 func (*UtilsStruct) SetConfig(flagSet *pflag.FlagSet) error {
-	_, _, _, err := InitializeCommandDependencies(flagSet)
+	_, _, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	flagDetails := []types.FlagDetail{

--- a/cmd/setDelegation.go
+++ b/cmd/setDelegation.go
@@ -32,7 +32,7 @@ func initialiseSetDelegation(cmd *cobra.Command, args []string) {
 
 //This function sets the flags appropriately and executes the SetDelegation function
 func (*UtilsStruct) ExecuteSetDelegation(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	statusString, err := flagSetUtils.GetStringStatus(flagSet)

--- a/cmd/stakerInfo.go
+++ b/cmd/stakerInfo.go
@@ -28,7 +28,7 @@ func initialiseStakerInfo(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the GetStakerInfo function
 func (*UtilsStruct) ExecuteStakerinfo(flagSet *pflag.FlagSet) {
-	_, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	_, rpcParameters, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	stakerId, err := flagSetUtils.GetUint32StakerId(flagSet)

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -32,7 +32,7 @@ func initialiseTransfer(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the Transfer function
 func (*UtilsStruct) ExecuteTransfer(flagSet *pflag.FlagSet) {
-	config, rpcParameters, _, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, _, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	log.Debugf("ExecuteTransfer: Config: %+v", config)

--- a/cmd/unlockWithdraw.go
+++ b/cmd/unlockWithdraw.go
@@ -31,7 +31,7 @@ func initializeUnlockWithdraw(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the UnlockWithdraw function
 func (*UtilsStruct) ExecuteUnlockWithdraw(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	stakerId, err := razorUtils.AssignStakerId(rpcParameters, flagSet, account.Address)

--- a/cmd/unstake.go
+++ b/cmd/unstake.go
@@ -35,7 +35,7 @@ func initialiseUnstake(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the Unstake function
 func (*UtilsStruct) ExecuteUnstake(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	log.Debug("Getting amount in wei...")

--- a/cmd/updateCollection.go
+++ b/cmd/updateCollection.go
@@ -34,7 +34,7 @@ func initialiseUpdateCollection(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the UpdateCollection function
 func (*UtilsStruct) ExecuteUpdateCollection(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	collectionId, err := flagSetUtils.GetUint16CollectionId(flagSet)

--- a/cmd/updateCommission.go
+++ b/cmd/updateCommission.go
@@ -31,7 +31,7 @@ func initialiseUpdateCommission(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the UpdateCommission function
 func (*UtilsStruct) ExecuteUpdateCommission(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	commission, err := flagSetUtils.GetUint8Commission(flagSet)

--- a/cmd/updateJob.go
+++ b/cmd/updateJob.go
@@ -34,7 +34,7 @@ func initialiseUpdateJob(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the UpdateJob function
 func (*UtilsStruct) ExecuteUpdateJob(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, _, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	jobId, err := flagSetUtils.GetUint16JobId(flagSet)

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"razor/block"
 	"razor/cache"
 	"razor/core"
 	"razor/core/types"
@@ -46,7 +47,7 @@ func initializeVote(cmd *cobra.Command, args []string) {
 
 //This function sets the flag appropriately and executes the Vote function
 func (*UtilsStruct) ExecuteVote(flagSet *pflag.FlagSet) {
-	config, rpcParameters, account, err := InitializeCommandDependencies(flagSet)
+	config, rpcParameters, blockMonitor, account, err := InitializeCommandDependencies(flagSet)
 	utils.CheckError("Error in initialising command dependencies: ", err)
 
 	err = ValidateBufferPercentLimit(rpcParameters, config.BufferPercent)
@@ -102,7 +103,7 @@ func (*UtilsStruct) ExecuteVote(flagSet *pflag.FlagSet) {
 	}
 
 	log.Debugf("Calling Vote() with arguments rogueData = %+v, account address = %s, backup node actions to ignore = %s", rogueData, account.Address, backupNodeActionsToIgnore)
-	if err := cmdUtils.Vote(rpcParameters, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore); err != nil {
+	if err := cmdUtils.Vote(rpcParameters, blockMonitor, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore); err != nil {
 		log.Errorf("%v\n", err)
 		osUtils.Exit(1)
 	}
@@ -133,20 +134,15 @@ func (*UtilsStruct) HandleExit() {
 }
 
 //This function handles all the states of voting
-func (*UtilsStruct) Vote(rpcParameters rpc.RPCParameters, config types.Configurations, account types.Account, stakerId uint32, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string) error {
-	header, err := clientUtils.GetLatestBlockWithRetry(rpcParameters)
-	utils.CheckError("Error in getting block: ", err)
+func (*UtilsStruct) Vote(rpcParameters rpc.RPCParameters, blockMonitor *block.BlockMonitor, config types.Configurations, account types.Account, stakerId uint32, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string) error {
+	header := blockMonitor.GetLatestBlock()
 	for {
 		select {
 		case <-rpcParameters.Ctx.Done():
 			return nil
 		default:
 			log.Debugf("Vote: Header value: %d", header.Number)
-			latestHeader, err := clientUtils.GetLatestBlockWithRetry(rpcParameters)
-			if err != nil {
-				log.Error("Error in fetching block: ", err)
-				continue
-			}
+			latestHeader := blockMonitor.GetLatestBlock()
 			log.Debugf("Vote: Latest header value: %d", latestHeader.Number)
 			if latestHeader.Number.Cmp(header.Number) != 0 {
 				header = latestHeader

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -144,6 +144,10 @@ func (*UtilsStruct) Vote(rpcParameters rpc.RPCParameters, blockMonitor *block.Bl
 		default:
 			log.Debugf("Vote: Header value: %d", header.Number)
 			latestHeader := blockMonitor.GetLatestBlock()
+			if latestHeader == nil {
+				log.Error("Block monitor returned nil header")
+				continue
+			}
 			log.Debugf("Vote: Latest header value: %d", latestHeader.Number)
 			if latestHeader.Number.Cmp(header.Number) != 0 {
 				header = latestHeader

--- a/cmd/vote.go
+++ b/cmd/vote.go
@@ -135,7 +135,8 @@ func (*UtilsStruct) HandleExit() {
 
 //This function handles all the states of voting
 func (*UtilsStruct) Vote(rpcParameters rpc.RPCParameters, blockMonitor *block.BlockMonitor, config types.Configurations, account types.Account, stakerId uint32, commitParams *types.CommitParams, rogueData types.Rogue, backupNodeActionsToIgnore []string) error {
-	header := blockMonitor.GetLatestBlock()
+	header, err := clientUtils.GetLatestBlockWithRetry(rpcParameters)
+	utils.CheckError("Error in getting block: ", err)
 	for {
 		select {
 		case <-rpcParameters.Ctx.Done():

--- a/cmd/vote_test.go
+++ b/cmd/vote_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	Types "github.com/ethereum/go-ethereum/core/types"
 	"math/big"
 	"os"
 	"path"
 	"path/filepath"
 	"razor/accounts"
+	"razor/block"
 	"razor/cache"
 	"razor/core/types"
 	"razor/pkg/bindings"
@@ -16,9 +18,6 @@ import (
 	"razor/utils"
 	"reflect"
 	"testing"
-	"time"
-
-	Types "github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -176,7 +175,7 @@ func TestExecuteVote(t *testing.T) {
 			flagSetMock.On("GetStringSliceRogueMode", mock.AnythingOfType("*pflag.FlagSet")).Return(tt.args.rogueMode, tt.args.rogueModeErr)
 			cmdUtilsMock.On("InitJobAndCollectionCache", mock.Anything).Return(&cache.JobsCache{}, &cache.CollectionsCache{}, big.NewInt(100), nil)
 			cmdUtilsMock.On("HandleExit").Return()
-			cmdUtilsMock.On("Vote", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.voteErr)
+			cmdUtilsMock.On("Vote", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.args.voteErr)
 			osMock.On("Exit", mock.AnythingOfType("int")).Return()
 
 			utils := &UtilsStruct{}
@@ -1338,11 +1337,8 @@ func TestVote(t *testing.T) {
 			errChan := make(chan error)
 			// Run Vote function in a goroutine
 			go func() {
-				errChan <- ut.Vote(localRpcParameters, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore)
+				errChan <- ut.Vote(localRpcParameters, &block.BlockMonitor{}, config, account, stakerId, commitParams, rogueData, backupNodeActionsToIgnore)
 			}()
-
-			// Wait for some time to allow Vote function to execute
-			time.Sleep(time.Second * 2)
 
 			// Cancel the context to simulate its done
 			cancel()


### PR DESCRIPTION
### **User description**
# Description

It was observed once for a staker that block number being reported by block monitor and block number reported in voting process were possibly due to different contexts as rpcManager instances for both modules is the same.

So fetching number directly from block monitor module wherever needed instead of making separate HeaderByNumber calls in voting module can fix the issue.

Fixes https://linear.app/interstellar-research/issue/RAZ-1239


# How Has This Been Tested?

Ran a staker for few epochs on staging and mainnet and observed block number in main voting loop.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored `InitializeCommandDependencies` to include `blockMonitor`.

- Updated `Vote` function to use `blockMonitor` for fetching latest block.

- Adjusted all command functions to accommodate the updated `InitializeCommandDependencies`.

- Enhanced unit tests to reflect changes in `Vote` function and `blockMonitor` usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>26 files</summary><table>
<tr>
  <td><strong>addStake.go</strong><dd><code>Adjusted <code>InitializeCommandDependencies</code> call to include <code>blockMonitor</code></code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-62f2c09eec4becc719eb95bc938ebde5a3ed94f8ef418772635b847ee4bade3f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>claimBounty.go</strong><dd><code>Updated <code>InitializeCommandDependencies</code> call for block monitor inclusion</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-0dc6976738225ef2ce3d8c5454e2965796ef3d48e94b70c07edff45343cab78e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>claimCommission.go</strong><dd><code>Refactored to include `blockMonitor` in dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-a97b603fa0bd1e49e0bf7b64d546b0f4f1de40d69f97f71aa8dde7159a46200e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cmd-utils.go</strong><dd><code>Refactored `InitializeCommandDependencies` to return `blockMonitor`</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-02c5dd149c4db12fd138d07fe2714c82e4cb28c4e2ce24fbac509cb6d14b37d3">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>collectionList.go</strong><dd><code>Updated `InitializeCommandDependencies` to include `blockMonitor`</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-ecaaff6a2865c8199f65cfc761952e3553d171091f8b0b414dd096163c985c9e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>contractAddresses.go</strong><dd><code>Adjusted `InitializeCommandDependencies` for additional return value</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-5aad066092efab5ebd913442e2d9e032af83e2740453115c1e3d18a91f3d596f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create.go</strong><dd><code>Updated `InitializeCommandDependencies` to include `blockMonitor`</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-e52f1f4fa0c533e3287cbe2ef0436582b5ca471a3fddcdf1f49fecd1ec0c7d13">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createCollection.go</strong><dd><code>Refactored to include `blockMonitor` in dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-a3c100ec838fa2ca78cdb3800f7bd1a44ea08b521d2985e308fe3621a70a5213">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>createJob.go</strong><dd><code>Adjusted `InitializeCommandDependencies` for block monitor inclusion</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-1bd86dc8e6f5c0cda63898cd820864d978ef109b31a0ef194487881b32a4d507">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>delegate.go</strong><dd><code>Updated `InitializeCommandDependencies` to include `blockMonitor`</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-a81383b0854317d77a57014dcde303edd9c6018dc790ca2e97ff9aca251b58c8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>import.go</strong><dd><code>Adjusted `InitializeCommandDependencies` for additional return value</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-6c8e635632861a9c32a970f525fc2b66f837f54ae39b4f6ec3a6350c9694c7db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>initiateWithdraw.go</strong><dd><code>Refactored to include `blockMonitor` in dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-c1c7d5070df99bade0661c289687bb2fc31b0c0732a324c6e75255e914b0340f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>interface.go</strong><dd><code>Updated `Vote` interface to include `blockMonitor`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-06620927ba1c55710752a6c29bed5934e598826e2fa7087a08570f9ce36858fe">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>jobList.go</strong><dd><code>Adjusted `InitializeCommandDependencies` for block monitor inclusion</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-66f5d71354b784d2753131a218880be4a181ef2753a0aa6cac3b38d7b87930f7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>modifyCollectionStatus.go</strong><dd><code>Refactored to include `blockMonitor` in dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-7f4fac88654aabd5d0fe582b9655718dd6e09fc9f54b0c55662d3e7208c5730c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resetUnstakeLock.go</strong><dd><code>Updated `InitializeCommandDependencies` for block monitor inclusion</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-26057fab932a85746cc327f05fc35194577cd989fdb8df2020e934b845ce0d19">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setConfig.go</strong><dd><code>Adjusted `InitializeCommandDependencies` for additional return value</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-aeecec91225c3e674d7ebbee9572a4c3ea0ef6bedb8b48afbf95917b7b286a0b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>setDelegation.go</strong><dd><code>Refactored to include `blockMonitor` in dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-2c5f2fd07940d7041617adbc5aa38b835bd7220a5b3739626706b2f99b81a321">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stakerInfo.go</strong><dd><code>Updated `InitializeCommandDependencies` to include `blockMonitor`</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-88181b15af0cc14ca25c027a5db270a635a3cd107dc089eff2579e0d491c4ca3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>transfer.go</strong><dd><code>Adjusted `InitializeCommandDependencies` for block monitor inclusion</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-b73e2ba1d6e1f5f2a759a3b2abf3d0deb2985da0c63cd78f292b64fd58da0010">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unlockWithdraw.go</strong><dd><code>Refactored to include `blockMonitor` in dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-78701afb7d108fb3e16663353611dccdc9ca083adfe0c6344f884a9c51e3a0bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unstake.go</strong><dd><code>Updated `InitializeCommandDependencies` for block monitor inclusion</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-043de8d1a64487a0e3fe911bc5715a7b5b7f22ee623826faa5d022667b5e5474">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>updateCollection.go</strong><dd><code>Adjusted `InitializeCommandDependencies` for additional return value</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-d74021479689130321d6d48a4355f4fe75945e1a30a0b2b574baa39ea1ea2787">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>updateCommission.go</strong><dd><code>Refactored to include `blockMonitor` in dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-554fe59e28dca97461068d4215b604498a75550921f3ea270cb23ba16f8726c0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>updateJob.go</strong><dd><code>Updated `InitializeCommandDependencies` to include `blockMonitor`</code></dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-e41afaf6c66a6e5b66c5c7b61e573c8b36d7672307012a46de303aab322c281e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vote.go</strong><dd><code>Refactored `Vote` function to use `blockMonitor`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-ab55f61e16ebf34217b7df771dd3902e32369cd013248b342d661d1cac7c9832">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>utils_cmd_interface.go</strong><dd><code>Updated mock for `Vote` to include `blockMonitor`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-892666eeb9af5579519d551bc1d713395362c9b9344a900defe247cac04b2d96">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vote_test.go</strong><dd><code>Updated tests to reflect `blockMonitor` usage in `Vote`</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1269/files#diff-1ca439b475b0e8689c2bf3d9bc2a81a5863bbef2dc087e95a0d195f10544e769">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>