### PR TITLE
fix: added validation to check if index to fetch element is within limit

### DIFF
--- a/cmd/propose.go
+++ b/cmd/propose.go
@@ -113,6 +113,12 @@ func (*UtilsStruct) Propose(rpcParameters rpc.RPCParameters, config types.Config
 			return err
 		}
 		log.Debug("Propose: Sorted proposed blocks: ", sortedProposedBlocks)
+
+		if numOfProposedBlocks <= 0 || len(sortedProposedBlocks) < int(numOfProposedBlocks) {
+			log.Errorf("Invalid numOfProposedBlocks (%d) or mismatch with sortedProposedBlocks length (%d)", numOfProposedBlocks, len(sortedProposedBlocks))
+			return errors.New("proposed blocks count mismatch")
+		}
+
 		lastBlockIndex := sortedProposedBlocks[numOfProposedBlocks-1]
 		log.Debug("Propose: Last block index: ", lastBlockIndex)
 		lastProposedBlockStruct, err := razorUtils.GetProposedBlock(rpcParameters, epoch, lastBlockIndex)

--- a/cmd/propose_test.go
+++ b/cmd/propose_test.go
@@ -497,6 +497,21 @@ func TestPropose(t *testing.T) {
 			},
 			wantErr: errors.New("txnOpts error"),
 		},
+		{
+			name: "Test 20: When there is a mismatch in number of proposed blocks and length of sorted proposed blocks array",
+			args: args{
+				state:                  2,
+				staker:                 bindings.StructsStaker{},
+				numStakers:             5,
+				biggestStake:           big.NewInt(1).Mul(big.NewInt(5356), big.NewInt(1e18)),
+				biggestStakerId:        2,
+				salt:                   saltBytes32,
+				iteration:              1,
+				numOfProposedBlocks:    3,
+				sortedProposedBlockIds: []uint32{2, 1},
+			},
+			wantErr: errors.New("proposed blocks count mismatch"),
+		},
 	}
 	for _, tt := range tests {
 		SetUpMockInterfaces()


### PR DESCRIPTION
### **User description**
# Description

A similar fix was merged from PR #1267 into the current public release branch as an hotfix release for releases/v2.0.0. However, this was only a beta release made available to a few stakers who were facing penalties on short notice.

We now need to merge the same changes again for releases/v2.1.0, as the earlier merge was not publicly released.

# Problem

Due to an RPC issue sometimes node was not able to fetch array length correctly from blockchain which was causing a staker to panic.

Fixes https://linear.app/interstellar-research/issue/RAZ-1241


# How Has This Been Tested?

Ran a staker for few epochs.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Added validation to check index bounds for proposed blocks.

- Enhanced error handling for mismatched block counts.

- Introduced a new test case for block count validation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>propose.go</strong><dd><code>Add validation for proposed block count mismatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/propose.go

<li>Added validation to check if <code>numOfProposedBlocks</code> is within bounds.<br> <li> Logged error and returned if block count mismatch occurs.


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1270/files#diff-5b85926c2bb6a36cc090f0cef10f19b2649be8e4b2c2de5323c6e1efabe3e66f">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>propose_test.go</strong><dd><code>Add test case for proposed block count validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/propose_test.go

<li>Added a new test case for block count mismatch.<br> <li> Validated error handling for mismatched proposed block counts.


</details>


  </td>
  <td><a href="https://github.com/razor-network/oracle-node/pull/1270/files#diff-477c112d01bc7070a8d89f03e2a0228cea459505ac2846bad32b774badb066d3">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>